### PR TITLE
feat: add skip-digest flag to skip posting PR digest

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,10 @@ inputs:
   config-file:
     description: 'Path to JSON Config file'
     required: true
+  skip-digest:
+    description: 'Skip posting the open PR digest to Slack'
+    required: false
+    default: 'false'
 
 runs:
   using: node20

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42374,6 +42374,7 @@ __nccwpck_require__.a(__webpack_module__, async (__webpack_handle_async_dependen
 async function run() {
   try {
     const { reactionConfig, channelConfig } = (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .getConfig */ .iE)();
+    const skipDigest = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)('skip-digest');
     for (let { channelId, limit, disableReactionCopying } of channelConfig) {
       const messagesForChannel = [];
       for (let message of await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .getMessages */ ._U)(channelId, limit)) {
@@ -42390,11 +42391,15 @@ async function run() {
           continue;
         }
 
-        messagesForChannel.push(
-          await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .buildPrMessage */ .wB)(channelId, message, pullRequests[0], reactionConfig, disableReactionCopying)
-        );
+        if (!skipDigest) {
+          messagesForChannel.push(
+            await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .buildPrMessage */ .wB)(channelId, message, pullRequests[0], reactionConfig, disableReactionCopying)
+          );
+        }
       }
-      await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .postOpenPrs */ .JZ)(channelId, messagesForChannel);
+      if (!skipDigest) {
+        await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .postOpenPrs */ .JZ)(channelId, messagesForChannel);
+      }
     }
   } catch (error) {
     console.error(error);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -23,9 +23,11 @@ export async function run() {
           continue;
         }
 
-        messagesForChannel.push(
-          await buildPrMessage(channelId, message, pullRequests[0], reactionConfig, disableReactionCopying)
-        );
+        if (!skipDigest) {
+          messagesForChannel.push(
+            await buildPrMessage(channelId, message, pullRequests[0], reactionConfig, disableReactionCopying)
+          );
+        }
       }
       if (!skipDigest) {
         await postOpenPrs(channelId, messagesForChannel);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,4 +1,4 @@
-import { setFailed } from "@actions/core";
+import { getBooleanInput, setFailed } from "@actions/core";
 import { getConfig, shouldProcess, getAggregateStatus, buildPrMessage } from "./workflow.mjs";
 import { getMessages, addReaction, postOpenPrs } from "./slack.mjs";
 import { extractPullRequests } from "./github.mjs"
@@ -6,6 +6,7 @@ import { extractPullRequests } from "./github.mjs"
 export async function run() {
   try {
     const { reactionConfig, channelConfig } = getConfig();
+    const skipDigest = getBooleanInput('skip-digest');
     for (let { channelId, limit, disableReactionCopying } of channelConfig) {
       const messagesForChannel = [];
       for (let message of await getMessages(channelId, limit)) {
@@ -26,7 +27,9 @@ export async function run() {
           await buildPrMessage(channelId, message, pullRequests[0], reactionConfig, disableReactionCopying)
         );
       }
-      await postOpenPrs(channelId, messagesForChannel);
+      if (!skipDigest) {
+        await postOpenPrs(channelId, messagesForChannel);
+      }
     }
   } catch (error) {
     console.error(error);


### PR DESCRIPTION
## Summary

- Adds a new optional `skip-digest` action input (default `false`) to `action.yml`
- When `true`, skips both building PR messages and posting the digest thread to Slack
- Closed/merged PR reactions still fire normally regardless of the flag

## Test Plan

- [ ] Run the action with `skip-digest: false` (or unset) — verify digest thread is posted as usual
- [ ] Run the action with `skip-digest: true` — verify no digest thread is posted, but merged/closed PRs still get reactions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
