### PR TITLE
feat: add PR tracking with persistent state, pagination, and allowBotMessages flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ jobs:
   pr-channel-slackbot:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Required when trackUnresolved is enabled (commits state file)
+      contents: write  # Required when any channel has trackUnresolved: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -123,9 +123,23 @@ jobs:
           slack-token: ${{ secrets.SLACK_TOKEN }}
           github-token: ${{ secrets.PR_BOT_GITHUB_TOKEN }}
           config-file: '.github/pr_channel_slackbot_config.json'
-          # skip-digest: true    # Uncomment to skip posting the open PR digest thread
-          # state-file: '.github/pr-channel-state.json'  # Customize state file location
+          state-file: '.github/pr-channel-state.json'
 ```
+
+With a matching config that enables `trackUnresolved` on a channel:
+
+```json
+{
+    "channels": {
+        "my-prs": {
+            "channelId": "C123456",
+            "trackUnresolved": true
+        }
+    }
+}
+```
+
+When `trackUnresolved` is enabled, the bot commits the updated state file back to the repository after each run (skipped if nothing changed), so previously-tracked unresolved PRs are carried forward even if they scroll outside the pagination window.
 
 ## Action Inputs
 
@@ -173,6 +187,8 @@ on:
 jobs:
   pr-channel-slackbot:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required when any channel has trackUnresolved: true
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -183,6 +199,7 @@ jobs:
           slack-token: ${{ secrets.SLACK_TOKEN }}
           github-token: ${{ secrets.PR_BOT_GITHUB_TOKEN }}
           config-file: '.github/pr_channel_slackbot_config.json'
+          state-file: '.github/pr-channel-state.json'
           skip-digest: ${{ github.event_name == 'schedule' && github.event.schedule == '0 9-17 * * 1-5' || inputs.skip-digest }}
 ```
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The PR Channel Slackbot action does the following steps for each configured Slac
    - The action adds a response within the thread for each message containing a link to an open pull request.
 
 5. **Copy Reactions**:
-   - Any reactions present on the original message are copied over to the response within the thread, ensuring continuity and visibility of feedback.  This can be disabled via 
+   - Any reactions present on the original message are copied over to the response within the thread, ensuring continuity and visibility of feedback. This can be disabled per-channel via `disableReactionCopying`.
 
 ### Example Output
 ![alt text](images/example.png)
@@ -99,8 +99,6 @@ The following permissions are required for the workflow to be able to check the 
 
 ## Example Workflow
 
-The following example workflow 
-
 ```yaml
 name: PR Channel Slackbot
 
@@ -113,6 +111,8 @@ on:
 jobs:
   pr-channel-slackbot:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Required when trackUnresolved is enabled (commits state file)
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -123,7 +123,8 @@ jobs:
           slack-token: ${{ secrets.SLACK_TOKEN }}
           github-token: ${{ secrets.PR_BOT_GITHUB_TOKEN }}
           config-file: '.github/pr_channel_slackbot_config.json'
-          # skip-digest: true  # Uncomment to skip posting the open PR digest thread
+          # skip-digest: true    # Uncomment to skip posting the open PR digest thread
+          # state-file: '.github/pr-channel-state.json'  # Customize state file location
 ```
 
 ## Action Inputs
@@ -134,6 +135,18 @@ jobs:
 | `github-token` | yes | | GitHub API token |
 | `config-file` | yes | | Path to the JSON configuration file |
 | `skip-digest` | no | `false` | When `true`, skips posting the open PR digest thread to Slack. Closed/merged PR reactions still fire normally. |
+| `state-file` | no | `./pr-channel-state.json` | Path to the state file used for persistent unresolved PR tracking. Only written when at least one channel has `trackUnresolved: true`. Requires `contents: write` permission on the workflow. |
+
+### When to use `state-file` / `trackUnresolved`
+
+When `trackUnresolved: true` is set on a channel, the bot persists the list of unresolved PR messages and the last digest thread timestamp to a JSON file after each run. On subsequent runs, it fetches any previously-tracked messages that fall outside the current pagination window, ensuring long-running PRs are never dropped from the digest.
+
+The state file is automatically committed and pushed back to the repository after each run (skipped if nothing changed). Set `contents: write` on the job permissions and ensure the `actions/checkout` step is present.
+
+```yaml
+permissions:
+  contents: write
+```
 
 ### When to use `skip-digest`
 
@@ -199,18 +212,21 @@ Example `pr_channel_slackbot_config.json`:
     "channels": {
         "project-foo-prs": {
             "channelId": "C123456",
-            "limit": 100
+            "limit": 100,
+            "maxPages": 2,
+            "trackUnresolved": true
         },
         "project-bar-prs": {
             "channelId": "C654321",
-            "disableReactionCopying": true
+            "disableReactionCopying": true,
+            "allowBotMessages": true
         },
         "project-baz-prs": {
             "channelId": "C987654",
             "limit": 50,
             "disabled": true
         }
-    },
+    }
 }
 ```
 
@@ -218,10 +234,10 @@ Example `pr_channel_slackbot_config.json`:
 
 The `reactions` section contains configuration for each reaction type used by the bot. Each reaction type accepts a list of reaction names that are considered to be part of that type.  If multiple reactions are provided for the same group, all of them will be considered matches when checking existing reactions on messages, but only the first one in the list will be used when the bot adds reactions.
 
-* `merged` - Any messages with a reaction in this group will be considered "resolved" (skipped).  If a pull request is merged in GitHub but not marked in Slack,  the first reaction from this group will be added to the message.
-* `merged` - Any messages with a reaction in this group will be considered "resolved" (skipped).  If a pull request is closed (without being merged) in GitHub but not marked in Slack,  the first reaction from this group will be added to the message.
-* `changesRequested` - Messages in this group do not impact how the bot processes Slack messages.  If a pull request is not closed, and it has been marked with requested changes, the first reaction from this group will be added to the message.
-* `approved` - Messages in this group do not impact how the bot processes Slack messages.  If a pull request is not closed, but has approvals on it (and no changes requested), the first reaction from this group will be added to the message.
+* `merged` - Any messages with a reaction in this group will be considered "resolved" (skipped). If a pull request is merged in GitHub but not marked in Slack, the first reaction from this group will be added to the message.
+* `closed` - Any messages with a reaction in this group will be considered "resolved" (skipped). If a pull request is closed (without being merged) in GitHub but not marked in Slack, the first reaction from this group will be added to the message.
+* `changesRequested` - Messages in this group do not impact how the bot processes Slack messages. If a pull request is not closed, and it has been marked with requested changes, the first reaction from this group will be added to the message.
+* `approved` - Messages in this group do not impact how the bot processes Slack messages. If a pull request is not closed, but has approvals on it (and no changes requested), the first reaction from this group will be added to the message.
 
 ### Channels
 
@@ -231,11 +247,14 @@ Each channel configuration can have the following fields:
 * `channelId` - (required) the ID of the channel.
     > [!NOTE]
     > If you do not know the ID of a channel, you can easily retrieve it from a link to that channel.  Simply right-click on the channel and select `Copy` > `Copy link`.  The last part of the link will be the channel ID.  For example, if your channel's link is `https://mycompany.slack.com/archives/C123456`, then the channel ID is `C123456`.
-* `limit` - (optional - default `50`) this limits how many messages in the channel will be reviewed for pull requests.  Only the last `<limit>` messages will be checked.
+* `limit` - (optional - default `50`) the maximum number of messages to fetch per page of Slack history.
     > [!NOTE]
     > It is recommended that you use a channel that is dedicated for pull requests to separate requests for reviews from other development-related conversations.  If your team is consistently reviewing pull requests, a large limit should not be required.
+* `maxPages` - (optional - default `1`) the maximum number of pages of Slack history to fetch. Increase this if your channel is high-volume and PRs may fall outside a single page. When `trackUnresolved` is enabled, pagination stops early once the previous digest thread is found.
+* `trackUnresolved` - (optional - default `false`) when `true`, the bot persists unresolved PR message timestamps and the last digest thread timestamp to the state file between runs. This ensures long-running PRs are never dropped from the digest even if they scroll outside the pagination window. Requires the `state-file` action input and `contents: write` workflow permission.
+* `allowBotMessages` - (optional - default `false`) when `true`, messages posted by bots are eligible for PR tracking. By default, bot messages are skipped.
 * `disabled` - (optional - default `false`) if you wish to disable a channel without completely removing it, you can mark it as disabled.
-* `disableReactionCopying` - (optional - default `false`) disable copying of reactions from the original post to the threads when `true`.
+* `disableReactionCopying` - (optional - default `false`) when `true`, reactions from the original message are not copied to the digest thread entry.
 
 ## License
 

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'Skip posting the open PR digest to Slack'
     required: false
     default: 'false'
+  state-file:
+    description: 'Path to the state file for tracking unresolved PRs and digest threads'
+    required: false
+    default: './pr-channel-state.json'
 
 runs:
   using: node20

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42757,17 +42757,24 @@ function getConfig() {
  * @param {boolean} trackUnresolved Whether to fetch individually-tracked messages
  * @returns {Promise<SlackMessage[]>} Deduplicated messages sorted ascending by ts
  */
-async function collectMessages(channelId, channelState, limit, maxPages, trackUnresolved) {
-  const { lastDigestThreadTimestamp, unresolvedMessageTimestamps } = channelState;
-
-  // Source 1: paginated history
-  const allFetchedMessages = [];
+/**
+ * Paginate channel history back to the last digest thread (or maxPages pages).
+ * Returns all fetched messages and the subset posted after the digest anchor.
+ *
+ * @param {string} channelId
+ * @param {number} limit Messages per page
+ * @param {number} maxPages Maximum pages to fetch
+ * @param {string|null} lastDigestThreadTimestamp Stop paginating when this ts is found
+ * @returns {Promise<{allMessages: SlackMessage[], postDigestMessages: SlackMessage[]}>}
+ */
+async function fetchPagedMessages(channelId, limit, maxPages, lastDigestThreadTimestamp) {
+  const allMessages = [];
   let cursor = undefined;
-
   let digestFound = false;
+
   for (let page = 0; page < maxPages; page++) {
     const { messages, nextCursor } = await (0,slack/* getMessagePage */.OT)(channelId, limit, cursor);
-    allFetchedMessages.push(...messages);
+    allMessages.push(...messages);
 
     if (lastDigestThreadTimestamp && messages.some(m => m.ts === lastDigestThreadTimestamp)) {
       digestFound = true;
@@ -42782,27 +42789,48 @@ async function collectMessages(channelId, channelState, limit, maxPages, trackUn
     console.warn(`Reached maxPages (${maxPages}) without finding last digest anchor for channel ${channelId}. Some messages may be missed. Consider increasing maxPages.`);
   }
 
-  console.info(`Fetched ${allFetchedMessages.length} messages across pages`);
+  console.info(`Fetched ${allMessages.length} messages across pages`);
 
-  const allFetchedTs = new Set(allFetchedMessages.map(m => m.ts));
   const postDigestMessages = lastDigestThreadTimestamp
-    ? allFetchedMessages.filter(m => parseFloat(m.ts) > parseFloat(lastDigestThreadTimestamp))
-    : [...allFetchedMessages];
+    ? allMessages.filter(m => parseFloat(m.ts) > parseFloat(lastDigestThreadTimestamp))
+    : [...allMessages];
 
-  // Source 2: previously-tracked messages that scrolled past the pagination window
-  const trackedMessages = [];
-  if (trackUnresolved) {
-    for (const ts of unresolvedMessageTimestamps) {
-      if (allFetchedTs.has(ts)) continue;
-      const message = await (0,slack/* getMessageByTimestamp */.D2)(channelId, ts);
-      if (message) {
-        trackedMessages.push(message);
-      }
+  return { allMessages, postDigestMessages };
+}
+
+/**
+ * Fetch previously-tracked unresolved messages that are not already in the fetched set.
+ * Skips any ts present in alreadyFetchedTs (message already retrieved via pagination).
+ * Skips any ts whose message has been deleted.
+ *
+ * @param {string} channelId
+ * @param {Array<string>} trackedTimestamps ts values from prior run state
+ * @param {Set<string>} alreadyFetchedTs ts values already retrieved in Source 1
+ * @returns {Promise<SlackMessage[]>}
+ */
+async function fetchTrackedMessages(channelId, trackedTimestamps, alreadyFetchedTs) {
+  const messages = [];
+  for (const ts of trackedTimestamps) {
+    if (alreadyFetchedTs.has(ts)) continue;
+    const message = await (0,slack/* getMessageByTimestamp */.D2)(channelId, ts);
+    if (message) {
+      messages.push(message);
     }
   }
+  return messages;
+}
 
-  // Merge and sort ascending — no deduplication needed since trackedMessages
-  // only contains ts values absent from allFetchedTs (and thus postDigestMessages)
+async function collectMessages(channelId, channelState, limit, maxPages, trackUnresolved) {
+  const { lastDigestThreadTimestamp, unresolvedMessageTimestamps } = channelState;
+
+  const { allMessages, postDigestMessages } = await fetchPagedMessages(
+    channelId, limit, maxPages, lastDigestThreadTimestamp
+  );
+
+  const trackedMessages = trackUnresolved
+    ? await fetchTrackedMessages(channelId, unresolvedMessageTimestamps, new Set(allMessages.map(m => m.ts)))
+    : [];
+
   const result = [...postDigestMessages, ...trackedMessages]
     .sort((a, b) => parseFloat(a.ts) - parseFloat(b.ts));
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42764,16 +42764,22 @@ async function collectMessages(channelId, channelState, limit, maxPages, trackUn
   const allFetchedMessages = [];
   let cursor = undefined;
 
+  let digestFound = false;
   for (let page = 0; page < maxPages; page++) {
     const { messages, nextCursor } = await (0,slack/* getMessagePage */.OT)(channelId, limit, cursor);
     allFetchedMessages.push(...messages);
 
     if (lastDigestThreadTimestamp && messages.some(m => m.ts === lastDigestThreadTimestamp)) {
+      digestFound = true;
       break;
     }
 
     if (!nextCursor) break;
     cursor = nextCursor;
+  }
+
+  if (lastDigestThreadTimestamp && !digestFound) {
+    console.warn(`Reached maxPages (${maxPages}) without finding last digest anchor for channel ${channelId}. Some messages may be missed. Consider increasing maxPages.`);
   }
 
   console.info(`Fetched ${allFetchedMessages.length} messages across pages`);

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42789,25 +42789,25 @@ async function collectMessages(channelId, channelState, limit, maxPages, trackUn
     ? allFetchedMessages.filter(m => parseFloat(m.ts) > parseFloat(lastDigestThreadTimestamp))
     : [...allFetchedMessages];
 
-  // Source 2: previously-tracked unresolved messages not seen in Source 1
-  const source2Messages = [];
+  // Source 2: previously-tracked messages that scrolled past the pagination window
+  const trackedMessages = [];
   if (trackUnresolved) {
     for (const ts of unresolvedMessageTimestamps) {
       if (allFetchedTs.has(ts)) continue;
       const message = await (0,slack/* getMessageByTimestamp */.D2)(channelId, ts);
       if (message) {
-        source2Messages.push(message);
+        trackedMessages.push(message);
       }
     }
   }
 
-  // Merge Source 1 post-digest + Source 2, deduplicate by ts, sort ascending
-  const merged = [...postDigestMessages, ...source2Messages];
-  const deduplicated = [...new Map(merged.map(m => [m.ts, m])).values()];
-  deduplicated.sort((a, b) => parseFloat(a.ts) - parseFloat(b.ts));
+  // Merge and sort ascending — no deduplication needed since trackedMessages
+  // only contains ts values absent from allFetchedTs (and thus postDigestMessages)
+  const result = [...postDigestMessages, ...trackedMessages]
+    .sort((a, b) => parseFloat(a.ts) - parseFloat(b.ts));
 
-  console.info(`Processing ${deduplicated.length} messages`);
-  return deduplicated;
+  console.info(`Processing ${result.length} messages`);
+  return result;
 }
 
 async function getAggregateStatus(pullRequests) {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42411,10 +42411,9 @@ async function run() {
         }
       }
 
-      let digestThreadTimestamp = channelState.lastDigestThreadTimestamp;
-      if (!skipDigest) {
-        digestThreadTimestamp = await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .postOpenPrs */ .JZ)(channelId, messagesForDigest);
-      }
+      const digestThreadTimestamp = (skipDigest
+        ? channelState.lastDigestThreadTimestamp
+        : await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .postOpenPrs */ .JZ)(channelId, messagesForDigest));
 
       state[channelId] = {
         unresolvedMessageTimestamps: unresolvedTimestamps,

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42366,6 +42366,8 @@ __nccwpck_require__.a(__webpack_module__, async (__webpack_handle_async_dependen
 /* harmony import */ var _workflow_mjs__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(6097);
 /* harmony import */ var _slack_mjs__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(8223);
 /* harmony import */ var _github_mjs__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(4852);
+/* harmony import */ var _state_mjs__WEBPACK_IMPORTED_MODULE_4__ = __nccwpck_require__(8354);
+
 
 
 
@@ -42375,9 +42377,18 @@ async function run() {
   try {
     const { reactionConfig, channelConfig } = (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .getConfig */ .iE)();
     const skipDigest = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getBooleanInput)('skip-digest');
-    for (let { channelId, limit, disableReactionCopying } of channelConfig) {
-      const messagesForChannel = [];
-      for (let message of await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .getMessages */ ._U)(channelId, limit)) {
+    const stateFile = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput)('state-file');
+
+    const state = (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .loadState */ .jw)(stateFile);
+
+    for (let { channelId, limit, maxPages, trackUnresolved, disableReactionCopying } of channelConfig) {
+      const channelState = (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .getChannelState */ .iJ)(state, channelId);
+      const messages = await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .collectMessages */ .$I)(channelId, channelState, limit, maxPages, trackUnresolved);
+
+      const messagesForDigest = [];
+      const unresolvedTimestamps = [];
+
+      for (let message of messages) {
         const pullRequests = (0,_github_mjs__WEBPACK_IMPORTED_MODULE_3__/* .extractPullRequests */ .Nd)(message.text);
 
         if (!(0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .shouldProcess */ .VM)(message, pullRequests, reactionConfig)) {
@@ -42391,16 +42402,27 @@ async function run() {
           continue;
         }
 
+        unresolvedTimestamps.push(message.ts);
+
         if (!skipDigest) {
-          messagesForChannel.push(
+          messagesForDigest.push(
             await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .buildPrMessage */ .wB)(channelId, message, pullRequests[0], reactionConfig, disableReactionCopying)
           );
         }
       }
+
+      let digestThreadTimestamp = channelState.lastDigestThreadTimestamp;
       if (!skipDigest) {
-        await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .postOpenPrs */ .JZ)(channelId, messagesForChannel);
+        digestThreadTimestamp = await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .postOpenPrs */ .JZ)(channelId, messagesForDigest);
       }
+
+      state[channelId] = {
+        unresolvedMessageTimestamps: unresolvedTimestamps,
+        lastDigestThreadTimestamp: digestThreadTimestamp
+      };
     }
+
+    (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .saveState */ .zL)(stateFile, state);
   } catch (error) {
     console.error(error);
     (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed)(error.message);
@@ -42418,8 +42440,9 @@ __webpack_async_result__();
 /***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
 
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
+/* harmony export */   "D2": () => (/* binding */ getMessageByTimestamp),
 /* harmony export */   "JZ": () => (/* binding */ postOpenPrs),
-/* harmony export */   "_U": () => (/* binding */ getMessages),
+/* harmony export */   "OT": () => (/* binding */ getMessagePage),
 /* harmony export */   "rU": () => (/* binding */ addReaction),
 /* harmony export */   "t5": () => (/* binding */ getPermalink)
 /* harmony export */ });
@@ -42441,19 +42464,40 @@ function slackClient() {
 }
 
 /**
- * Get the last {limit} messages from {channelId} in ascending order.
- * 
+ * Fetch a single page of messages from {channelId}.
  * @param {string} channelId
  * @param {number} limit
+ * @param {string} [cursor]
+ * @returns {Promise<{messages: SlackMessage[], nextCursor: string|null}>}
  */
-async function getMessages(channelId, limit) {
-  const history = await slackClient().conversations.history({
+async function getMessagePage(channelId, limit, cursor = undefined) {
+  const response = await slackClient().conversations.history({
     channel: channelId,
-    limit
+    limit,
+    cursor
   });
-  console.info(`Processing ${history.messages?.length ?? 0} messages`);
-  return (history.messages ?? [])
-    .sort((a, b) => parseFloat(a.ts) - parseFloat(b.ts));
+  return {
+    messages: response.messages ?? [],
+    nextCursor: response.response_metadata?.next_cursor || null
+  };
+}
+
+/**
+ * Fetch a single message by its timestamp.
+ * Returns null if the message does not exist (deleted).
+ * @param {string} channelId
+ * @param {string} ts
+ * @returns {Promise<SlackMessage|null>}
+ */
+async function getMessageByTimestamp(channelId, ts) {
+  const response = await slackClient().conversations.history({
+    channel: channelId,
+    oldest: ts,
+    latest: ts,
+    inclusive: true,
+    limit: 1
+  });
+  return response.messages?.[0] ?? null;
 }
 
 function addReaction(channelId, messageTs, reaction) {
@@ -42473,7 +42517,7 @@ function getPermalink(channelId, messageTs) {
 
 async function postOpenPrs(channelId, messages) {
   const headerResponse = await postThreadHeader(channelId, messages.length);
-  if (messages.length === 0) return;
+  if (messages.length === 0) return headerResponse.ts;
 
   for (let message of messages) {
     const prMessage = await postPrMessage(channelId, headerResponse.ts, message);
@@ -42481,6 +42525,7 @@ async function postOpenPrs(channelId, messages) {
       await addReaction(channelId, prMessage.ts, reaction);
     }
   }
+  return headerResponse.ts;
 }
 
 async function postThreadHeader(channelId, prCount) {
@@ -42514,6 +42559,97 @@ async function postPrMessage(channelId, threadId, message) {
 
 /***/ }),
 
+/***/ 8354:
+/***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
+
+
+// EXPORTS
+__nccwpck_require__.d(__webpack_exports__, {
+  "iJ": () => (/* binding */ getChannelState),
+  "jw": () => (/* binding */ loadState),
+  "zL": () => (/* binding */ saveState)
+});
+
+// EXTERNAL MODULE: external "fs"
+var external_fs_ = __nccwpck_require__(7147);
+;// CONCATENATED MODULE: external "child_process"
+const external_child_process_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("child_process");
+;// CONCATENATED MODULE: ./src/state.mjs
+
+
+
+/**
+ * @typedef {Object} ChannelState
+ * @property {Array<string>} unresolvedMessageTimestamps
+ * @property {string|null} lastDigestThreadTimestamp
+ */
+
+/**
+ * Run a git command, throwing if it exits non-zero or fails to spawn.
+ * @param {string[]} args
+ */
+function git(...args) {
+  const result = (0,external_child_process_namespaceObject.spawnSync)('git', args, { stdio: 'inherit' });
+  if (result.error || result.status !== 0) {
+    const detail = result.error ? result.error.message : `exit status ${result.status}`;
+    throw new Error(`git ${args.join(' ')} failed: ${detail}`);
+  }
+}
+
+/**
+ * Load state from the state file.
+ * Returns {} if the file does not exist (clean first run).
+ * @param {string} stateFile
+ * @returns {Object.<string, ChannelState>}
+ */
+function loadState(stateFile) {
+  if (!external_fs_.existsSync(stateFile)) {
+    return {};
+  }
+  return JSON.parse(external_fs_.readFileSync(stateFile, 'utf-8'));
+}
+
+/**
+ * Get the state for a channel with defaults applied.
+ * @param {Object.<string, ChannelState>} state
+ * @param {string} channelId
+ * @returns {ChannelState}
+ */
+function getChannelState(state, channelId) {
+  return {
+    unresolvedMessageTimestamps: [],
+    lastDigestThreadTimestamp: null,
+    ...(state[channelId] ?? {})
+  };
+}
+
+/**
+ * Write state to disk and commit it to the repo.
+ * Skips the commit if the file has not changed.
+ * Throws if git operations fail (caller should handle via setFailed).
+ * @param {string} stateFile
+ * @param {Object.<string, ChannelState>} state
+ */
+function saveState(stateFile, state) {
+  external_fs_.writeFileSync(stateFile, JSON.stringify(state, null, 2));
+  git('add', stateFile);
+  const diff = (0,external_child_process_namespaceObject.spawnSync)('git', ['diff', '--cached', '--exit-code', '--', stateFile], { stdio: 'ignore' });
+  if (diff.error) throw new Error(`git diff failed: ${diff.error.message}`);
+  if (diff.status === 0) {
+    console.info('No changes to state file, skipping commit.');
+    return;
+  }
+  git('commit', '-m', 'chore: update PR channel state [skip ci]');
+  const refName = process.env.GITHUB_REF_NAME;
+  if (!refName) {
+    throw new Error('GITHUB_REF_NAME is not set; cannot push state file');
+  }
+  git('push', 'origin', `HEAD:refs/heads/${refName}`);
+}
+
+
+/***/ }),
+
 /***/ 6097:
 /***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
 
@@ -42521,6 +42657,7 @@ async function postPrMessage(channelId, threadId, message) {
 // EXPORTS
 __nccwpck_require__.d(__webpack_exports__, {
   "wB": () => (/* binding */ buildPrMessage),
+  "$I": () => (/* binding */ collectMessages),
   "di": () => (/* binding */ getAggregateStatus),
   "iE": () => (/* binding */ getConfig),
   "VM": () => (/* binding */ shouldProcess)
@@ -42565,6 +42702,8 @@ function distinct(array) {
  * @typedef {Object} ChannelConfig
  * @property {string} channelId
  * @property {number} limit
+ * @property {number} maxPages
+ * @property {boolean} trackUnresolved
  * @property {boolean} disableReactionCopying
  */
 /**
@@ -42593,6 +42732,8 @@ function getConfig() {
     .map(it => ({
       ...it,
       limit: it.limit ?? 50,
+      maxPages: it.maxPages ?? 1,
+      trackUnresolved: it.trackUnresolved ?? false,
       disableReactionCopying: it.disableReactionCopying ?? false
     }))
     .filter(it => it.channelId && !it.disabled);
@@ -42601,6 +42742,66 @@ function getConfig() {
     reactionConfig,
     channelConfig
   };
+}
+
+/**
+ * Build the unified message set for a channel from two sources:
+ * 1. Paginated Slack history back to the last digest thread (or maxPages pages).
+ * 2. Individually-fetched messages for previously-tracked unresolved timestamps
+ *    not already present in the paginated results (only when trackUnresolved is true).
+ *
+ * @param {string} channelId
+ * @param {import('./state.mjs').ChannelState} channelState
+ * @param {number} limit Messages per page
+ * @param {number} maxPages Maximum pages to fetch
+ * @param {boolean} trackUnresolved Whether to fetch individually-tracked messages
+ * @returns {Promise<SlackMessage[]>} Deduplicated messages sorted ascending by ts
+ */
+async function collectMessages(channelId, channelState, limit, maxPages, trackUnresolved) {
+  const { lastDigestThreadTimestamp, unresolvedMessageTimestamps } = channelState;
+
+  // Source 1: paginated history
+  const allFetchedMessages = [];
+  let cursor = undefined;
+
+  for (let page = 0; page < maxPages; page++) {
+    const { messages, nextCursor } = await (0,slack/* getMessagePage */.OT)(channelId, limit, cursor);
+    allFetchedMessages.push(...messages);
+
+    if (lastDigestThreadTimestamp && messages.some(m => m.ts === lastDigestThreadTimestamp)) {
+      break;
+    }
+
+    if (!nextCursor) break;
+    cursor = nextCursor;
+  }
+
+  console.info(`Fetched ${allFetchedMessages.length} messages across pages`);
+
+  const allFetchedTs = new Set(allFetchedMessages.map(m => m.ts));
+  const postDigestMessages = lastDigestThreadTimestamp
+    ? allFetchedMessages.filter(m => parseFloat(m.ts) > parseFloat(lastDigestThreadTimestamp))
+    : [...allFetchedMessages];
+
+  // Source 2: previously-tracked unresolved messages not seen in Source 1
+  const source2Messages = [];
+  if (trackUnresolved) {
+    for (const ts of unresolvedMessageTimestamps) {
+      if (allFetchedTs.has(ts)) continue;
+      const message = await (0,slack/* getMessageByTimestamp */.D2)(channelId, ts);
+      if (message) {
+        source2Messages.push(message);
+      }
+    }
+  }
+
+  // Merge Source 1 post-digest + Source 2, deduplicate by ts, sort ascending
+  const merged = [...postDigestMessages, ...source2Messages];
+  const deduplicated = [...new Map(merged.map(m => [m.ts, m])).values()];
+  deduplicated.sort((a, b) => parseFloat(a.ts) - parseFloat(b.ts));
+
+  console.info(`Processing ${deduplicated.length} messages`);
+  return deduplicated;
 }
 
 async function getAggregateStatus(pullRequests) {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42423,7 +42423,9 @@ async function run() {
       }
     }
 
-    (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .saveState */ .zL)(stateFile, state);
+    if (channelConfig.some(c => c.trackUnresolved)) {
+      (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .saveState */ .zL)(stateFile, state);
+    }
   } catch (error) {
     console.error(error);
     (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed)(error.message);
@@ -42587,7 +42589,7 @@ const external_child_process_namespaceObject = __WEBPACK_EXTERNAL_createRequire(
 
 /**
  * Run a git command, throwing if it exits non-zero or fails to spawn.
- * @param {string[]} args
+ * @param {...string} args
  */
 function git(...args) {
   const result = (0,external_child_process_namespaceObject.spawnSync)('git', args, { stdio: 'inherit' });
@@ -42748,19 +42750,6 @@ function getConfig() {
 }
 
 /**
- * Build the unified message set for a channel from two sources:
- * 1. Paginated Slack history back to the last digest thread (or maxPages pages).
- * 2. Individually-fetched messages for previously-tracked unresolved timestamps
- *    not already present in the paginated results (only when trackUnresolved is true).
- *
- * @param {string} channelId
- * @param {import('./state.mjs').ChannelState} channelState
- * @param {number} limit Messages per page
- * @param {number} maxPages Maximum pages to fetch
- * @param {boolean} trackUnresolved Whether to fetch individually-tracked messages
- * @returns {Promise<SlackMessage[]>} Deduplicated messages sorted ascending by ts
- */
-/**
  * Paginate channel history back to the last digest thread (or maxPages pages).
  * Returns all fetched messages and the subset posted after the digest anchor.
  *
@@ -42823,6 +42812,19 @@ async function fetchTrackedMessages(channelId, trackedTimestamps, alreadyFetched
   return messages;
 }
 
+/**
+ * Build the unified message set for a channel from two sources:
+ * 1. Paginated Slack history back to the last digest thread (or maxPages pages).
+ * 2. Individually-fetched messages for previously-tracked unresolved timestamps
+ *    not already present in the paginated results (only when trackUnresolved is true).
+ *
+ * @param {string} channelId
+ * @param {import('./state.mjs').ChannelState} channelState
+ * @param {number} limit Messages per page
+ * @param {number} maxPages Maximum pages to fetch
+ * @param {boolean} trackUnresolved Whether to fetch individually-tracked messages
+ * @returns {Promise<SlackMessage[]>} Deduplicated messages sorted ascending by ts
+ */
 async function collectMessages(channelId, channelState, limit, maxPages, trackUnresolved) {
   const { lastDigestThreadTimestamp, unresolvedMessageTimestamps } = channelState;
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42381,7 +42381,7 @@ async function run() {
 
     const state = (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .loadState */ .jw)(stateFile);
 
-    for (let { channelId, limit, maxPages, trackUnresolved, disableReactionCopying } of channelConfig) {
+    for (let { channelId, limit, maxPages, trackUnresolved, disableReactionCopying, allowBotMessages } of channelConfig) {
       const channelState = (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .getChannelState */ .iJ)(state, channelId);
       const messages = await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .collectMessages */ .$I)(channelId, channelState, limit, maxPages, trackUnresolved);
 
@@ -42391,7 +42391,7 @@ async function run() {
       for (let message of messages) {
         const pullRequests = (0,_github_mjs__WEBPACK_IMPORTED_MODULE_3__/* .extractPullRequests */ .Nd)(message.text);
 
-        if (!(0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .shouldProcess */ .VM)(message, pullRequests, reactionConfig)) {
+        if (!(0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .shouldProcess */ .VM)(message, pullRequests, reactionConfig, allowBotMessages)) {
           continue;
         }
 
@@ -42415,10 +42415,12 @@ async function run() {
         ? channelState.lastDigestThreadTimestamp
         : await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .postOpenPrs */ .JZ)(channelId, messagesForDigest));
 
-      state[channelId] = {
-        unresolvedMessageTimestamps: unresolvedTimestamps,
-        lastDigestThreadTimestamp: digestThreadTimestamp
-      };
+      if (trackUnresolved) {
+        state[channelId] = {
+          unresolvedMessageTimestamps: unresolvedTimestamps,
+          lastDigestThreadTimestamp: digestThreadTimestamp
+        };
+      }
     }
 
     (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .saveState */ .zL)(stateFile, state);
@@ -42704,6 +42706,7 @@ function distinct(array) {
  * @property {number} maxPages
  * @property {boolean} trackUnresolved
  * @property {boolean} disableReactionCopying
+ * @property {boolean} allowBotMessages
  */
 /**
  * @typedef {Object} PrMessage
@@ -42733,7 +42736,8 @@ function getConfig() {
       limit: it.limit ?? 50,
       maxPages: it.maxPages ?? 1,
       trackUnresolved: it.trackUnresolved ?? false,
-      disableReactionCopying: it.disableReactionCopying ?? false
+      disableReactionCopying: it.disableReactionCopying ?? false,
+      allowBotMessages: it.allowBotMessages ?? false
     }))
     .filter(it => it.channelId && !it.disabled);
 
@@ -42823,7 +42827,7 @@ async function collectMessages(channelId, channelState, limit, maxPages, trackUn
   const { lastDigestThreadTimestamp, unresolvedMessageTimestamps } = channelState;
 
   const { allMessages, postDigestMessages } = await fetchPagedMessages(
-    channelId, limit, maxPages, lastDigestThreadTimestamp
+    channelId, limit, maxPages, trackUnresolved ? lastDigestThreadTimestamp : null
   );
 
   const trackedMessages = trackUnresolved
@@ -42855,8 +42859,9 @@ async function getAggregateStatus(pullRequests) {
  * @param {SlackMessage} message
  * @param {Array<PullRequest>} pullRequests
  * @param {ReactionConfig} reactionConfig
+ * @param {boolean} allowBotMessages
  */
-function shouldProcess(message, pullRequests, reactionConfig) {
+function shouldProcess(message, pullRequests, reactionConfig, allowBotMessages = false) {
   if (pullRequests.length === 0) {
     console.debug(`SKIPPING: ${message.ts} has no pull requests`);
     return false;
@@ -42864,7 +42869,7 @@ function shouldProcess(message, pullRequests, reactionConfig) {
     console.warn(`WARNING: ${message.ts} has multiple pull requests`);
   }
 
-  if (message.bot_id) {
+  if (!allowBotMessages && message.bot_id) {
     console.debug(`SKIPPING: ${message.ts} is a bot message`);
     return false;
   }
@@ -42875,10 +42880,6 @@ function shouldProcess(message, pullRequests, reactionConfig) {
   }
 
   console.debug(`PROCESSING: ${message.ts}`);
-  if (pullRequests.length > 1) {
-    console.warn(`WARNING: ${message.ts} has multiple pull requests`);
-  }
-
   return true;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@slack/web-api": "^7.0.4"
       },
       "devDependencies": {
-        "@vercel/ncc": "^0.38.1"
+        "@vercel/ncc": "^0.38.1",
+        "vitest": "^4.1.4"
       }
     },
     "node_modules/@actions/core": {
@@ -46,12 +47,72 @@
         "undici": "^5.25.4"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
+      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@fastify/busboy": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@octokit/auth-token": {
@@ -198,6 +259,280 @@
         "@octokit/openapi-types": "^22.2.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.124.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.124.0.tgz",
+      "integrity": "sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YYe6aWruPZDtHNpwu7+qAHEMbQ/yRl6atqb/AhznLTnD3UY99Q1jE7ihLSahNWkF4EqRPVC4SiR4O0UkLK02tA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-oArR/ig8wNTPYsXL+Mzhs0oxhxfuHRfG7Ikw7jXsw8mYOtk71W0OkF2VEVh699pdmzjPQsTjlD1JIOoHkLP1Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-YzeVqOqjPYvUbJSWJ4EDL8ahbmsIXQpgL3JVipmN+MX0XnXMeWomLN3Fb+nwCmP/jfyqte5I3XRSm7OfQrbyxw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-9Erhx956jeQ0nNTyif1+QWAXDRD38ZNjr//bSHrt6wDwB+QkAfl2q6Mn1k6OBPerznjRmbM10lgRb1Pli4xZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.15.tgz",
+      "integrity": "sha512-cVwk0w8QbZJGTnP/AHQBs5yNwmpgGYStL88t4UIaqcvYJWBfS0s3oqVLZPwsPU6M0zlW4GqjP0Zq5MnAGwFeGA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-eBZ/u8iAK9SoHGanqe/jrPnY0JvBN6iXbVOsbO38mbz+ZJsaobExAm1Iu+rxa4S1l2FjG0qEZn4Rc6X8n+9M+w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.15.tgz",
+      "integrity": "sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.15.tgz",
+      "integrity": "sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.15.tgz",
+      "integrity": "sha512-ApLruZq/ig+nhaE7OJm4lDjayUnOHVUa77zGeqnqZ9pn0ovdVbbNPerVibLXDmWeUZXjIYIT8V3xkT58Rm9u5Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.9.2",
+        "@emnapi/runtime": "1.9.2",
+        "@napi-rs/wasm-runtime": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-KmoUoU7HnN+Si5YWJigfTws1jz1bKBYDQKdbLspz0UaqjjFkddHsqorgiW1mxcAj88lYUE6NC/zJNwT+SloqtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.15.tgz",
+      "integrity": "sha512-3P2A8L+x75qavWLe/Dll3EYBJLQmtkJN8rfh+U/eR3MqMgL/h98PhYI+JFfXuDPgPeCB7iZAKiqii5vqOvnA0g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.15.tgz",
+      "integrity": "sha512-UromN0peaE53IaBRe9W7CjrZgXl90fqGpK+mIZbA3qSTeYqg3pqpROBdIPvOG3F5ereDHNwoHBI2e50n1BDr1g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@slack/logger": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.0.tgz",
@@ -242,12 +577,56 @@
         "npm": ">= 8.6.0"
       }
     },
-    "node_modules/@types/node": {
-      "version": "20.12.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.8.tgz",
-      "integrity": "sha512-NU0rJLJnshZWdE/097cdCBbyW1h4hEg0xpovcoAQYHl8dnEyp/NAOiE45pvc+Bd1Dt+2r94v2eGFpQJ4R7g+2w==",
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
       }
     },
     "node_modules/@types/retry": {
@@ -262,6 +641,129 @@
       "dev": true,
       "bin": {
         "ncc": "dist/ncc/cli.js"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.4.tgz",
+      "integrity": "sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.4.tgz",
+      "integrity": "sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.4.tgz",
+      "integrity": "sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.4.tgz",
+      "integrity": "sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.4",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.4.tgz",
+      "integrity": "sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.4.tgz",
+      "integrity": "sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.4.tgz",
+      "integrity": "sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.4",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/asynckit": {
@@ -284,6 +786,16 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -294,6 +806,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -308,10 +827,65 @@
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
       "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/follow-redirects": {
       "version": "1.15.6",
@@ -345,6 +919,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/is-electron": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
@@ -359,6 +948,277 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/mime-db": {
@@ -379,6 +1239,36 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -439,6 +1329,62 @@
         "node": ">=8"
       }
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -451,6 +1397,123 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.0-rc.15",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
+      "integrity": "sha512-Ff31guA5zT6WjnGp0SXw76X6hzGRk/OQq2hE+1lcDe+lJdHSgnSX6nK3erbONHyCbpSj9a9E+uX/OvytZoWp2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.124.0",
+        "@rolldown/pluginutils": "1.0.0-rc.15"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.15",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.15",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.15",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.15",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.15",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.15",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -472,9 +1535,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
     },
     "node_modules/universal-user-agent": {
       "version": "6.0.1",
@@ -487,6 +1551,191 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vite": {
+      "version": "8.0.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.8.tgz",
+      "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.8",
+        "rolldown": "1.0.0-rc.15",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.4.tgz",
+      "integrity": "sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.4",
+        "@vitest/mocker": "4.1.4",
+        "@vitest/pretty-format": "4.1.4",
+        "@vitest/runner": "4.1.4",
+        "@vitest/snapshot": "4.1.4",
+        "@vitest/spy": "4.1.4",
+        "@vitest/utils": "4.1.4",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.4",
+        "@vitest/browser-preview": "4.1.4",
+        "@vitest/browser-webdriverio": "4.1.4",
+        "@vitest/coverage-istanbul": "4.1.4",
+        "@vitest/coverage-v8": "4.1.4",
+        "@vitest/ui": "4.1.4",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Simple Slackbot for managing a PR channel",
   "main": "dist/index.mjs",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "build": "ncc build src/index.mjs -o dist"
   },
   "repository": {
@@ -24,7 +24,8 @@
   },
   "homepage": "https://github.com/TheSench/pr-channel-slackbot#readme",
   "devDependencies": {
-    "@vercel/ncc": "^0.38.1"
+    "@vercel/ncc": "^0.38.1",
+    "vitest": "^4.1.4"
   },
   "dependencies": {
     "@actions/core": "^1.10.1",

--- a/src/github.test.mjs
+++ b/src/github.test.mjs
@@ -1,0 +1,38 @@
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('@actions/core', () => ({ getInput: vi.fn() }));
+vi.mock('@actions/github', () => ({ getOctokit: vi.fn() }));
+
+import { extractPullRequests } from './github.mjs';
+
+describe('extractPullRequests', () => {
+  it('returns an empty array when text contains no GitHub PR URLs', () => {
+    expect(extractPullRequests('Check out https://example.com for details')).toEqual([]);
+  });
+
+  it('returns an empty array for an empty string', () => {
+    expect(extractPullRequests('')).toEqual([]);
+  });
+
+  it('extracts a single PR URL into owner, repo, and pull_number', () => {
+    const text = 'Please review: https://github.com/myorg/myrepo/pull/42';
+    expect(extractPullRequests(text)).toEqual([
+      { owner: 'myorg', repo: 'myrepo', pull_number: '42' },
+    ]);
+  });
+
+  it('extracts multiple PR URLs from the same message', () => {
+    const text = 'Related PRs: https://github.com/org/repo1/pull/1 and https://github.com/org/repo2/pull/2';
+    expect(extractPullRequests(text)).toEqual([
+      { owner: 'org', repo: 'repo1', pull_number: '1' },
+      { owner: 'org', repo: 'repo2', pull_number: '2' },
+    ]);
+  });
+
+  it('handles PR URLs embedded within surrounding text', () => {
+    const text = 'Review <https://github.com/org/repo/pull/99> before EOD!';
+    expect(extractPullRequests(text)).toEqual([
+      { owner: 'org', repo: 'repo', pull_number: '99' },
+    ]);
+  });
+});

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -12,7 +12,7 @@ export async function run() {
 
     const state = loadState(stateFile);
 
-    for (let { channelId, limit, maxPages, trackUnresolved, disableReactionCopying } of channelConfig) {
+    for (let { channelId, limit, maxPages, trackUnresolved, disableReactionCopying, allowBotMessages } of channelConfig) {
       const channelState = getChannelState(state, channelId);
       const messages = await collectMessages(channelId, channelState, limit, maxPages, trackUnresolved);
 
@@ -22,7 +22,7 @@ export async function run() {
       for (let message of messages) {
         const pullRequests = extractPullRequests(message.text);
 
-        if (!shouldProcess(message, pullRequests, reactionConfig)) {
+        if (!shouldProcess(message, pullRequests, reactionConfig, allowBotMessages)) {
           continue;
         }
 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -46,10 +46,12 @@ export async function run() {
         ? channelState.lastDigestThreadTimestamp
         : await postOpenPrs(channelId, messagesForDigest));
 
-      state[channelId] = {
-        unresolvedMessageTimestamps: unresolvedTimestamps,
-        lastDigestThreadTimestamp: digestThreadTimestamp
-      };
+      if (trackUnresolved) {
+        state[channelId] = {
+          unresolvedMessageTimestamps: unresolvedTimestamps,
+          lastDigestThreadTimestamp: digestThreadTimestamp
+        };
+      }
     }
 
     saveState(stateFile, state);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,15 +1,25 @@
-import { getBooleanInput, setFailed } from "@actions/core";
-import { getConfig, shouldProcess, getAggregateStatus, buildPrMessage } from "./workflow.mjs";
-import { getMessages, addReaction, postOpenPrs } from "./slack.mjs";
-import { extractPullRequests } from "./github.mjs"
+import { getBooleanInput, getInput, setFailed } from "@actions/core";
+import { getConfig, shouldProcess, getAggregateStatus, buildPrMessage, collectMessages } from "./workflow.mjs";
+import { addReaction, postOpenPrs } from "./slack.mjs";
+import { extractPullRequests } from "./github.mjs";
+import { loadState, saveState, getChannelState } from "./state.mjs";
 
 export async function run() {
   try {
     const { reactionConfig, channelConfig } = getConfig();
     const skipDigest = getBooleanInput('skip-digest');
-    for (let { channelId, limit, disableReactionCopying } of channelConfig) {
-      const messagesForChannel = [];
-      for (let message of await getMessages(channelId, limit)) {
+    const stateFile = getInput('state-file');
+
+    const state = loadState(stateFile);
+
+    for (let { channelId, limit, maxPages, trackUnresolved, disableReactionCopying } of channelConfig) {
+      const channelState = getChannelState(state, channelId);
+      const messages = await collectMessages(channelId, channelState, limit, maxPages, trackUnresolved);
+
+      const messagesForDigest = [];
+      const unresolvedTimestamps = [];
+
+      for (let message of messages) {
         const pullRequests = extractPullRequests(message.text);
 
         if (!shouldProcess(message, pullRequests, reactionConfig)) {
@@ -23,16 +33,27 @@ export async function run() {
           continue;
         }
 
+        unresolvedTimestamps.push(message.ts);
+
         if (!skipDigest) {
-          messagesForChannel.push(
+          messagesForDigest.push(
             await buildPrMessage(channelId, message, pullRequests[0], reactionConfig, disableReactionCopying)
           );
         }
       }
+
+      let digestThreadTimestamp = channelState.lastDigestThreadTimestamp;
       if (!skipDigest) {
-        await postOpenPrs(channelId, messagesForChannel);
+        digestThreadTimestamp = await postOpenPrs(channelId, messagesForDigest);
       }
+
+      state[channelId] = {
+        unresolvedMessageTimestamps: unresolvedTimestamps,
+        lastDigestThreadTimestamp: digestThreadTimestamp
+      };
     }
+
+    saveState(stateFile, state);
   } catch (error) {
     console.error(error);
     setFailed(error.message);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -54,7 +54,9 @@ export async function run() {
       }
     }
 
-    saveState(stateFile, state);
+    if (channelConfig.some(c => c.trackUnresolved)) {
+      saveState(stateFile, state);
+    }
   } catch (error) {
     console.error(error);
     setFailed(error.message);

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -42,10 +42,9 @@ export async function run() {
         }
       }
 
-      let digestThreadTimestamp = channelState.lastDigestThreadTimestamp;
-      if (!skipDigest) {
-        digestThreadTimestamp = await postOpenPrs(channelId, messagesForDigest);
-      }
+      const digestThreadTimestamp = (skipDigest
+        ? channelState.lastDigestThreadTimestamp
+        : await postOpenPrs(channelId, messagesForDigest));
 
       state[channelId] = {
         unresolvedMessageTimestamps: unresolvedTimestamps,

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -31,9 +31,11 @@ vi.mock('./state.mjs', () => ({
 }));
 
 import { run } from './index.mjs';
-import { getConfig, collectMessages } from './workflow.mjs';
+import { getConfig, collectMessages, shouldProcess, getAggregateStatus, buildPrMessage } from './workflow.mjs';
 import { loadState, saveState, getChannelState } from './state.mjs';
-import { postOpenPrs } from './slack.mjs';
+import { postOpenPrs, addReaction } from './slack.mjs';
+import { extractPullRequests } from './github.mjs';
+import { getBooleanInput, setFailed } from '@actions/core';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -41,6 +43,9 @@ beforeEach(() => {
   getConfig.mockReturnValue({ reactionConfig: { merged: [], closed: [] }, channelConfig: [] });
   loadState.mockReturnValue({});
   postOpenPrs.mockResolvedValue('digest-ts');
+  // Reset these explicitly since vi.clearAllMocks() does not reset mockReturnValue
+  getBooleanInput.mockReturnValue(false);
+  shouldProcess.mockReturnValue(false);
 });
 
 const BASE_CHANNEL = {
@@ -86,6 +91,106 @@ describe('run()', () => {
 
       const [, savedState] = saveState.mock.calls[0];
       expect(savedState).toHaveProperty('C123');
+    });
+  });
+
+  describe('when a message has a resolved PR', () => {
+    const PR_MESSAGE = { ts: '123.0', text: 'PR message' };
+
+    beforeEach(() => {
+      getConfig.mockReturnValue({
+        reactionConfig: { merged: ['white-check-mark'], closed: ['x'], approved: ['approved'], changesRequested: ['changes-requested'] },
+        channelConfig: [{ ...BASE_CHANNEL, trackUnresolved: false }],
+      });
+      collectMessages.mockResolvedValue([PR_MESSAGE]);
+      extractPullRequests.mockReturnValue([{ owner: 'org', repo: 'repo', pull_number: '1' }]);
+      shouldProcess.mockReturnValue(true);
+    });
+
+    it('adds a reaction when the PR is merged', async () => {
+      getAggregateStatus.mockResolvedValue('merged');
+
+      await run();
+
+      expect(addReaction).toHaveBeenCalledWith('C123', PR_MESSAGE.ts, 'white-check-mark');
+    });
+
+    it('adds a reaction when the PR is closed', async () => {
+      getAggregateStatus.mockResolvedValue('closed');
+
+      await run();
+
+      expect(addReaction).toHaveBeenCalledWith('C123', PR_MESSAGE.ts, 'x');
+    });
+  });
+
+  describe('when a message has an open PR', () => {
+    const PR_MESSAGE = { ts: '123.0', text: 'PR message' };
+    const DIGEST_ENTRY = { permalink: 'https://slack.com/link', reactions: ['approved'] };
+
+    beforeEach(() => {
+      getConfig.mockReturnValue({
+        reactionConfig: { merged: ['merged'], closed: ['closed'], approved: ['approved'], changesRequested: ['changes-requested'] },
+        channelConfig: [{ ...BASE_CHANNEL, trackUnresolved: true }],
+      });
+      collectMessages.mockResolvedValue([PR_MESSAGE]);
+      extractPullRequests.mockReturnValue([{}]);
+      shouldProcess.mockReturnValue(true);
+      getAggregateStatus.mockResolvedValue('open');
+      buildPrMessage.mockResolvedValue(DIGEST_ENTRY);
+    });
+
+    it('includes the message in the digest', async () => {
+      await run();
+
+      expect(postOpenPrs).toHaveBeenCalledWith('C123', [DIGEST_ENTRY]);
+    });
+
+    it('records the message timestamp as unresolved in state', async () => {
+      await run();
+
+      const [, savedState] = saveState.mock.calls[0];
+      expect(savedState['C123'].unresolvedMessageTimestamps).toContain(PR_MESSAGE.ts);
+    });
+  });
+
+  describe('when skip-digest is true', () => {
+    const PREV_DIGEST_TS = 'prev-digest-ts';
+
+    beforeEach(() => {
+      getBooleanInput.mockReturnValue(true);
+      getConfig.mockReturnValue({
+        reactionConfig: { merged: ['merged'], closed: ['closed'] },
+        channelConfig: [{ ...BASE_CHANNEL, trackUnresolved: true }],
+      });
+      getChannelState.mockReturnValue({
+        unresolvedMessageTimestamps: [],
+        lastDigestThreadTimestamp: PREV_DIGEST_TS,
+      });
+      collectMessages.mockResolvedValue([]);
+    });
+
+    it('does not post a new digest thread', async () => {
+      await run();
+
+      expect(postOpenPrs).not.toHaveBeenCalled();
+    });
+
+    it('preserves the previous digest thread timestamp in state', async () => {
+      await run();
+
+      const [, savedState] = saveState.mock.calls[0];
+      expect(savedState['C123'].lastDigestThreadTimestamp).toBe(PREV_DIGEST_TS);
+    });
+  });
+
+  describe('when an error occurs', () => {
+    it('reports the failure without throwing', async () => {
+      getConfig.mockImplementation(() => { throw new Error('Config not found'); });
+
+      await run();
+
+      expect(setFailed).toHaveBeenCalledWith('Config not found');
     });
   });
 });

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -53,6 +53,7 @@ const BASE_CHANNEL = {
   limit: 50,
   maxPages: 1,
   disableReactionCopying: false,
+  allowBotMessages: false,
 };
 
 describe('run()', () => {
@@ -192,5 +193,19 @@ describe('run()', () => {
 
       expect(setFailed).toHaveBeenCalledWith('Config not found');
     });
+  });
+
+  it('passes allowBotMessages from channel config to shouldProcess', async () => {
+    const PR_MESSAGE = { ts: '1.0', text: 'PR link' };
+    getConfig.mockReturnValue({
+      reactionConfig: { merged: ['merged'], closed: ['closed'] },
+      channelConfig: [{ ...BASE_CHANNEL, trackUnresolved: false, allowBotMessages: true }],
+    });
+    collectMessages.mockResolvedValue([PR_MESSAGE]);
+    extractPullRequests.mockReturnValue([{}]);
+
+    await run();
+
+    expect(shouldProcess).toHaveBeenCalledWith(PR_MESSAGE, [{}], expect.any(Object), true);
   });
 });

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -71,8 +71,7 @@ describe('run()', () => {
 
       await run();
 
-      const [, savedState] = saveState.mock.calls[0];
-      expect(savedState).not.toHaveProperty('C123');
+      expect(saveState).not.toHaveBeenCalled();
     });
   });
 

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -1,0 +1,91 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// All vi.mock calls are hoisted before imports, so these are in place
+// when index.mjs loads and its top-level `await run()` executes.
+vi.mock('@actions/core', () => ({
+  getBooleanInput: vi.fn(() => false),
+  getInput: vi.fn(() => 'state.json'),
+  setFailed: vi.fn(),
+}));
+vi.mock('./workflow.mjs', () => ({
+  getConfig: vi.fn(() => ({ reactionConfig: { merged: [], closed: [] }, channelConfig: [] })),
+  collectMessages: vi.fn().mockResolvedValue([]),
+  shouldProcess: vi.fn(() => false),
+  getAggregateStatus: vi.fn(),
+  buildPrMessage: vi.fn(),
+}));
+vi.mock('./slack.mjs', () => ({
+  addReaction: vi.fn(),
+  postOpenPrs: vi.fn().mockResolvedValue('digest-ts'),
+}));
+vi.mock('./github.mjs', () => ({
+  extractPullRequests: vi.fn(() => []),
+}));
+vi.mock('./state.mjs', () => ({
+  loadState: vi.fn(() => ({})),
+  saveState: vi.fn(),
+  getChannelState: vi.fn(() => ({
+    unresolvedMessageTimestamps: [],
+    lastDigestThreadTimestamp: null,
+  })),
+}));
+
+import { run } from './index.mjs';
+import { getConfig, collectMessages } from './workflow.mjs';
+import { loadState, saveState, getChannelState } from './state.mjs';
+import { postOpenPrs } from './slack.mjs';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Safe defaults: empty channel list so the initial module-load run is a no-op
+  getConfig.mockReturnValue({ reactionConfig: { merged: [], closed: [] }, channelConfig: [] });
+  loadState.mockReturnValue({});
+  postOpenPrs.mockResolvedValue('digest-ts');
+});
+
+const BASE_CHANNEL = {
+  channelId: 'C123',
+  limit: 50,
+  maxPages: 1,
+  disableReactionCopying: false,
+};
+
+describe('run()', () => {
+  describe('when trackUnresolved is false', () => {
+    it('does not save state for the channel', async () => {
+      getConfig.mockReturnValue({
+        reactionConfig: { merged: ['merged'], closed: ['closed'] },
+        channelConfig: [{ ...BASE_CHANNEL, trackUnresolved: false }],
+      });
+      getChannelState.mockReturnValue({
+        unresolvedMessageTimestamps: [],
+        lastDigestThreadTimestamp: 'prev-digest-ts',
+      });
+      collectMessages.mockResolvedValue([]);
+
+      await run();
+
+      const [, savedState] = saveState.mock.calls[0];
+      expect(savedState).not.toHaveProperty('C123');
+    });
+  });
+
+  describe('when trackUnresolved is true', () => {
+    it('saves state for the channel', async () => {
+      getConfig.mockReturnValue({
+        reactionConfig: { merged: ['merged'], closed: ['closed'] },
+        channelConfig: [{ ...BASE_CHANNEL, trackUnresolved: true }],
+      });
+      getChannelState.mockReturnValue({
+        unresolvedMessageTimestamps: [],
+        lastDigestThreadTimestamp: 'prev-digest-ts',
+      });
+      collectMessages.mockResolvedValue([]);
+
+      await run();
+
+      const [, savedState] = saveState.mock.calls[0];
+      expect(savedState).toHaveProperty('C123');
+    });
+  });
+});

--- a/src/slack.mjs
+++ b/src/slack.mjs
@@ -14,22 +14,6 @@ function slackClient() {
 }
 
 /**
- * Get the last {limit} messages from {channelId} in ascending order.
- * 
- * @param {string} channelId
- * @param {number} limit
- */
-export async function getMessages(channelId, limit) {
-  const history = await slackClient().conversations.history({
-    channel: channelId,
-    limit
-  });
-  console.info(`Processing ${history.messages?.length ?? 0} messages`);
-  return (history.messages ?? [])
-    .sort((a, b) => parseFloat(a.ts) - parseFloat(b.ts));
-}
-
-/**
  * Fetch a single page of messages from {channelId}.
  * @param {string} channelId
  * @param {number} limit

--- a/src/slack.mjs
+++ b/src/slack.mjs
@@ -29,6 +29,43 @@ export async function getMessages(channelId, limit) {
     .sort((a, b) => parseFloat(a.ts) - parseFloat(b.ts));
 }
 
+/**
+ * Fetch a single page of messages from {channelId}.
+ * @param {string} channelId
+ * @param {number} limit
+ * @param {string} [cursor]
+ * @returns {Promise<{messages: SlackMessage[], nextCursor: string|null}>}
+ */
+export async function getMessagePage(channelId, limit, cursor = undefined) {
+  const response = await slackClient().conversations.history({
+    channel: channelId,
+    limit,
+    cursor
+  });
+  return {
+    messages: response.messages ?? [],
+    nextCursor: response.response_metadata?.next_cursor || null
+  };
+}
+
+/**
+ * Fetch a single message by its timestamp.
+ * Returns null if the message does not exist (deleted).
+ * @param {string} channelId
+ * @param {string} ts
+ * @returns {Promise<SlackMessage|null>}
+ */
+export async function getMessageByTimestamp(channelId, ts) {
+  const response = await slackClient().conversations.history({
+    channel: channelId,
+    oldest: ts,
+    latest: ts,
+    inclusive: true,
+    limit: 1
+  });
+  return response.messages?.[0] ?? null;
+}
+
 export function addReaction(channelId, messageTs, reaction) {
   return slackClient().reactions.add({
     name: reaction,
@@ -46,7 +83,7 @@ export function getPermalink(channelId, messageTs) {
 
 export async function postOpenPrs(channelId, messages) {
   const headerResponse = await postThreadHeader(channelId, messages.length);
-  if (messages.length === 0) return;
+  if (messages.length === 0) return headerResponse.ts;
 
   for (let message of messages) {
     const prMessage = await postPrMessage(channelId, headerResponse.ts, message);
@@ -54,6 +91,7 @@ export async function postOpenPrs(channelId, messages) {
       await addReaction(channelId, prMessage.ts, reaction);
     }
   }
+  return headerResponse.ts;
 }
 
 async function postThreadHeader(channelId, prCount) {

--- a/src/state.mjs
+++ b/src/state.mjs
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import { execSync } from 'child_process';
+
+/**
+ * @typedef {Object} ChannelState
+ * @property {Array<string>} unresolvedMessageTimestamps
+ * @property {string|null} lastDigestThreadTimestamp
+ */
+
+/**
+ * Load state from the state file.
+ * Returns {} if the file does not exist (clean first run).
+ * @param {string} stateFile
+ * @returns {Object.<string, ChannelState>}
+ */
+export function loadState(stateFile) {
+  if (!fs.existsSync(stateFile)) {
+    return {};
+  }
+  return JSON.parse(fs.readFileSync(stateFile, 'utf-8'));
+}
+
+/**
+ * Get the state for a channel with defaults applied.
+ * @param {Object.<string, ChannelState>} state
+ * @param {string} channelId
+ * @returns {ChannelState}
+ */
+export function getChannelState(state, channelId) {
+  return {
+    unresolvedMessageTimestamps: [],
+    lastDigestThreadTimestamp: null,
+    ...(state[channelId] ?? {})
+  };
+}
+
+/**
+ * Write state to disk and commit it to the repo.
+ * Skips the commit if the file has not changed.
+ * Throws if git operations fail (caller should handle via setFailed).
+ * @param {string} stateFile
+ * @param {Object.<string, ChannelState>} state
+ */
+export function saveState(stateFile, state) {
+  fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
+  execSync(`git add "${stateFile}"`);
+  try {
+    execSync(`git diff --cached --exit-code -- "${stateFile}"`, { stdio: 'ignore' });
+    console.info('No changes to state file, skipping commit.');
+    return;
+  } catch {
+    // Staged changes exist — proceed with commit
+  }
+  execSync(`git commit -m "chore: update PR channel state [skip ci]"`);
+  execSync(`git push`);
+}

--- a/src/state.mjs
+++ b/src/state.mjs
@@ -9,7 +9,7 @@ import { spawnSync } from 'child_process';
 
 /**
  * Run a git command, throwing if it exits non-zero or fails to spawn.
- * @param {string[]} args
+ * @param {...string} args
  */
 function git(...args) {
   const result = spawnSync('git', args, { stdio: 'inherit' });

--- a/src/state.mjs
+++ b/src/state.mjs
@@ -1,11 +1,22 @@
 import fs from 'fs';
-import { execSync } from 'child_process';
+import { spawnSync } from 'child_process';
 
 /**
  * @typedef {Object} ChannelState
  * @property {Array<string>} unresolvedMessageTimestamps
  * @property {string|null} lastDigestThreadTimestamp
  */
+
+/**
+ * Run a git command, throwing if it exits non-zero.
+ * @param {string[]} args
+ */
+function git(...args) {
+  const result = spawnSync('git', args, { stdio: 'inherit' });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(' ')} exited with status ${result.status}`);
+  }
+}
 
 /**
  * Load state from the state file.
@@ -43,14 +54,12 @@ export function getChannelState(state, channelId) {
  */
 export function saveState(stateFile, state) {
   fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
-  execSync(`git add "${stateFile}"`);
-  try {
-    execSync(`git diff --cached --exit-code -- "${stateFile}"`, { stdio: 'ignore' });
+  git('add', stateFile);
+  const diff = spawnSync('git', ['diff', '--cached', '--exit-code', '--', stateFile], { stdio: 'ignore' });
+  if (diff.status === 0) {
     console.info('No changes to state file, skipping commit.');
     return;
-  } catch {
-    // Staged changes exist — proceed with commit
   }
-  execSync(`git commit -m "chore: update PR channel state [skip ci]"`);
-  execSync(`git push`);
+  git('commit', '-m', 'chore: update PR channel state [skip ci]');
+  git('push', 'origin', `HEAD:refs/heads/${process.env.GITHUB_REF_NAME}`);
 }

--- a/src/state.mjs
+++ b/src/state.mjs
@@ -8,13 +8,14 @@ import { spawnSync } from 'child_process';
  */
 
 /**
- * Run a git command, throwing if it exits non-zero.
+ * Run a git command, throwing if it exits non-zero or fails to spawn.
  * @param {string[]} args
  */
 function git(...args) {
   const result = spawnSync('git', args, { stdio: 'inherit' });
-  if (result.status !== 0) {
-    throw new Error(`git ${args.join(' ')} exited with status ${result.status}`);
+  if (result.error || result.status !== 0) {
+    const detail = result.error ? result.error.message : `exit status ${result.status}`;
+    throw new Error(`git ${args.join(' ')} failed: ${detail}`);
   }
 }
 
@@ -56,10 +57,15 @@ export function saveState(stateFile, state) {
   fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
   git('add', stateFile);
   const diff = spawnSync('git', ['diff', '--cached', '--exit-code', '--', stateFile], { stdio: 'ignore' });
+  if (diff.error) throw new Error(`git diff failed: ${diff.error.message}`);
   if (diff.status === 0) {
     console.info('No changes to state file, skipping commit.');
     return;
   }
   git('commit', '-m', 'chore: update PR channel state [skip ci]');
-  git('push', 'origin', `HEAD:refs/heads/${process.env.GITHUB_REF_NAME}`);
+  const refName = process.env.GITHUB_REF_NAME;
+  if (!refName) {
+    throw new Error('GITHUB_REF_NAME is not set; cannot push state file');
+  }
+  git('push', 'origin', `HEAD:refs/heads/${refName}`);
 }

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -64,19 +64,6 @@ export function getConfig() {
 }
 
 /**
- * Build the unified message set for a channel from two sources:
- * 1. Paginated Slack history back to the last digest thread (or maxPages pages).
- * 2. Individually-fetched messages for previously-tracked unresolved timestamps
- *    not already present in the paginated results (only when trackUnresolved is true).
- *
- * @param {string} channelId
- * @param {import('./state.mjs').ChannelState} channelState
- * @param {number} limit Messages per page
- * @param {number} maxPages Maximum pages to fetch
- * @param {boolean} trackUnresolved Whether to fetch individually-tracked messages
- * @returns {Promise<SlackMessage[]>} Deduplicated messages sorted ascending by ts
- */
-/**
  * Paginate channel history back to the last digest thread (or maxPages pages).
  * Returns all fetched messages and the subset posted after the digest anchor.
  *
@@ -139,6 +126,19 @@ async function fetchTrackedMessages(channelId, trackedTimestamps, alreadyFetched
   return messages;
 }
 
+/**
+ * Build the unified message set for a channel from two sources:
+ * 1. Paginated Slack history back to the last digest thread (or maxPages pages).
+ * 2. Individually-fetched messages for previously-tracked unresolved timestamps
+ *    not already present in the paginated results (only when trackUnresolved is true).
+ *
+ * @param {string} channelId
+ * @param {import('./state.mjs').ChannelState} channelState
+ * @param {number} limit Messages per page
+ * @param {number} maxPages Maximum pages to fetch
+ * @param {boolean} trackUnresolved Whether to fetch individually-tracked messages
+ * @returns {Promise<SlackMessage[]>} Deduplicated messages sorted ascending by ts
+ */
 export async function collectMessages(channelId, channelState, limit, maxPages, trackUnresolved) {
   const { lastDigestThreadTimestamp, unresolvedMessageTimestamps } = channelState;
 

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -22,6 +22,7 @@ import { distinct } from './utils.mjs';
  * @property {number} maxPages
  * @property {boolean} trackUnresolved
  * @property {boolean} disableReactionCopying
+ * @property {boolean} allowBotMessages
  */
 /**
  * @typedef {Object} PrMessage
@@ -51,7 +52,8 @@ export function getConfig() {
       limit: it.limit ?? 50,
       maxPages: it.maxPages ?? 1,
       trackUnresolved: it.trackUnresolved ?? false,
-      disableReactionCopying: it.disableReactionCopying ?? false
+      disableReactionCopying: it.disableReactionCopying ?? false,
+      allowBotMessages: it.allowBotMessages ?? false
     }))
     .filter(it => it.channelId && !it.disabled);
 

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -141,7 +141,7 @@ export async function collectMessages(channelId, channelState, limit, maxPages, 
   const { lastDigestThreadTimestamp, unresolvedMessageTimestamps } = channelState;
 
   const { allMessages, postDigestMessages } = await fetchPagedMessages(
-    channelId, limit, maxPages, lastDigestThreadTimestamp
+    channelId, limit, maxPages, trackUnresolved ? lastDigestThreadTimestamp : null
   );
 
   const trackedMessages = trackUnresolved

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -74,17 +74,24 @@ export function getConfig() {
  * @param {boolean} trackUnresolved Whether to fetch individually-tracked messages
  * @returns {Promise<SlackMessage[]>} Deduplicated messages sorted ascending by ts
  */
-export async function collectMessages(channelId, channelState, limit, maxPages, trackUnresolved) {
-  const { lastDigestThreadTimestamp, unresolvedMessageTimestamps } = channelState;
-
-  // Source 1: paginated history
-  const allFetchedMessages = [];
+/**
+ * Paginate channel history back to the last digest thread (or maxPages pages).
+ * Returns all fetched messages and the subset posted after the digest anchor.
+ *
+ * @param {string} channelId
+ * @param {number} limit Messages per page
+ * @param {number} maxPages Maximum pages to fetch
+ * @param {string|null} lastDigestThreadTimestamp Stop paginating when this ts is found
+ * @returns {Promise<{allMessages: SlackMessage[], postDigestMessages: SlackMessage[]}>}
+ */
+async function fetchPagedMessages(channelId, limit, maxPages, lastDigestThreadTimestamp) {
+  const allMessages = [];
   let cursor = undefined;
-
   let digestFound = false;
+
   for (let page = 0; page < maxPages; page++) {
     const { messages, nextCursor } = await getMessagePage(channelId, limit, cursor);
-    allFetchedMessages.push(...messages);
+    allMessages.push(...messages);
 
     if (lastDigestThreadTimestamp && messages.some(m => m.ts === lastDigestThreadTimestamp)) {
       digestFound = true;
@@ -99,26 +106,48 @@ export async function collectMessages(channelId, channelState, limit, maxPages, 
     console.warn(`Reached maxPages (${maxPages}) without finding last digest anchor for channel ${channelId}. Some messages may be missed. Consider increasing maxPages.`);
   }
 
-  console.info(`Fetched ${allFetchedMessages.length} messages across pages`);
+  console.info(`Fetched ${allMessages.length} messages across pages`);
 
-  const allFetchedTs = new Set(allFetchedMessages.map(m => m.ts));
   const postDigestMessages = lastDigestThreadTimestamp
-    ? allFetchedMessages.filter(m => parseFloat(m.ts) > parseFloat(lastDigestThreadTimestamp))
-    : [...allFetchedMessages];
+    ? allMessages.filter(m => parseFloat(m.ts) > parseFloat(lastDigestThreadTimestamp))
+    : [...allMessages];
 
-  // Source 2: previously-tracked messages that scrolled past the pagination window
-  const trackedMessages = [];
-  if (trackUnresolved) {
-    for (const ts of unresolvedMessageTimestamps) {
-      if (allFetchedTs.has(ts)) continue;
-      const message = await getMessageByTimestamp(channelId, ts);
-      if (message) {
-        trackedMessages.push(message);
-      }
+  return { allMessages, postDigestMessages };
+}
+
+/**
+ * Fetch previously-tracked unresolved messages that are not already in the fetched set.
+ * Skips any ts present in alreadyFetchedTs (message already retrieved via pagination).
+ * Skips any ts whose message has been deleted.
+ *
+ * @param {string} channelId
+ * @param {Array<string>} trackedTimestamps ts values from prior run state
+ * @param {Set<string>} alreadyFetchedTs ts values already retrieved in Source 1
+ * @returns {Promise<SlackMessage[]>}
+ */
+async function fetchTrackedMessages(channelId, trackedTimestamps, alreadyFetchedTs) {
+  const messages = [];
+  for (const ts of trackedTimestamps) {
+    if (alreadyFetchedTs.has(ts)) continue;
+    const message = await getMessageByTimestamp(channelId, ts);
+    if (message) {
+      messages.push(message);
     }
   }
+  return messages;
+}
 
-  // Merge and sort ascending by timestamp
+export async function collectMessages(channelId, channelState, limit, maxPages, trackUnresolved) {
+  const { lastDigestThreadTimestamp, unresolvedMessageTimestamps } = channelState;
+
+  const { allMessages, postDigestMessages } = await fetchPagedMessages(
+    channelId, limit, maxPages, lastDigestThreadTimestamp
+  );
+
+  const trackedMessages = trackUnresolved
+    ? await fetchTrackedMessages(channelId, unresolvedMessageTimestamps, new Set(allMessages.map(m => m.ts)))
+    : [];
+
   const result = [...postDigestMessages, ...trackedMessages]
     .sort((a, b) => parseFloat(a.ts) - parseFloat(b.ts));
 

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -106,25 +106,24 @@ export async function collectMessages(channelId, channelState, limit, maxPages, 
     ? allFetchedMessages.filter(m => parseFloat(m.ts) > parseFloat(lastDigestThreadTimestamp))
     : [...allFetchedMessages];
 
-  // Source 2: previously-tracked unresolved messages not seen in Source 1
-  const source2Messages = [];
+  // Source 2: previously-tracked messages that scrolled past the pagination window
+  const trackedMessages = [];
   if (trackUnresolved) {
     for (const ts of unresolvedMessageTimestamps) {
       if (allFetchedTs.has(ts)) continue;
       const message = await getMessageByTimestamp(channelId, ts);
       if (message) {
-        source2Messages.push(message);
+        trackedMessages.push(message);
       }
     }
   }
 
-  // Merge Source 1 post-digest + Source 2, deduplicate by ts, sort ascending
-  const merged = [...postDigestMessages, ...source2Messages];
-  const deduplicated = [...new Map(merged.map(m => [m.ts, m])).values()];
-  deduplicated.sort((a, b) => parseFloat(a.ts) - parseFloat(b.ts));
+  // Merge and sort ascending by timestamp
+  const result = [...postDigestMessages, ...trackedMessages]
+    .sort((a, b) => parseFloat(a.ts) - parseFloat(b.ts));
 
-  console.info(`Processing ${deduplicated.length} messages`);
-  return deduplicated;
+  console.info(`Processing ${result.length} messages`);
+  return result;
 }
 
 export async function getAggregateStatus(pullRequests) {

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -196,10 +196,6 @@ export function shouldProcess(message, pullRequests, reactionConfig, allowBotMes
   }
 
   console.debug(`PROCESSING: ${message.ts}`);
-  if (pullRequests.length > 1) {
-    console.warn(`WARNING: ${message.ts} has multiple pull requests`);
-  }
-
   return true;
 }
 

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -175,8 +175,9 @@ export async function getAggregateStatus(pullRequests) {
  * @param {SlackMessage} message
  * @param {Array<PullRequest>} pullRequests
  * @param {ReactionConfig} reactionConfig
+ * @param {boolean} allowBotMessages
  */
-export function shouldProcess(message, pullRequests, reactionConfig) {
+export function shouldProcess(message, pullRequests, reactionConfig, allowBotMessages = false) {
   if (pullRequests.length === 0) {
     console.debug(`SKIPPING: ${message.ts} has no pull requests`);
     return false;
@@ -184,7 +185,7 @@ export function shouldProcess(message, pullRequests, reactionConfig) {
     console.warn(`WARNING: ${message.ts} has multiple pull requests`);
   }
 
-  if (message.bot_id) {
+  if (!allowBotMessages && message.bot_id) {
     console.debug(`SKIPPING: ${message.ts} is a bot message`);
     return false;
   }

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -1,7 +1,7 @@
 import { getInput } from '@actions/core';
 import fs from 'fs';
 import { getPullRequestStatus, getReviewReactions } from './github.mjs';
-import { getPermalink } from './slack.mjs';
+import { getPermalink, getMessagePage, getMessageByTimestamp } from './slack.mjs';
 import { distinct } from './utils.mjs';
 
 /** @typedef {import('./slack.mjs').SlackMessage} SlackMessage */
@@ -19,6 +19,8 @@ import { distinct } from './utils.mjs';
  * @typedef {Object} ChannelConfig
  * @property {string} channelId
  * @property {number} limit
+ * @property {number} maxPages
+ * @property {boolean} trackUnresolved
  * @property {boolean} disableReactionCopying
  */
 /**
@@ -47,6 +49,8 @@ export function getConfig() {
     .map(it => ({
       ...it,
       limit: it.limit ?? 50,
+      maxPages: it.maxPages ?? 1,
+      trackUnresolved: it.trackUnresolved ?? false,
       disableReactionCopying: it.disableReactionCopying ?? false
     }))
     .filter(it => it.channelId && !it.disabled);
@@ -55,6 +59,66 @@ export function getConfig() {
     reactionConfig,
     channelConfig
   };
+}
+
+/**
+ * Build the unified message set for a channel from two sources:
+ * 1. Paginated Slack history back to the last digest thread (or maxPages pages).
+ * 2. Individually-fetched messages for previously-tracked unresolved timestamps
+ *    not already present in the paginated results (only when trackUnresolved is true).
+ *
+ * @param {string} channelId
+ * @param {import('./state.mjs').ChannelState} channelState
+ * @param {number} limit Messages per page
+ * @param {number} maxPages Maximum pages to fetch
+ * @param {boolean} trackUnresolved Whether to fetch individually-tracked messages
+ * @returns {Promise<SlackMessage[]>} Deduplicated messages sorted ascending by ts
+ */
+export async function collectMessages(channelId, channelState, limit, maxPages, trackUnresolved) {
+  const { lastDigestThreadTimestamp, unresolvedMessageTimestamps } = channelState;
+
+  // Source 1: paginated history
+  const allFetchedMessages = [];
+  let cursor = undefined;
+
+  for (let page = 0; page < maxPages; page++) {
+    const { messages, nextCursor } = await getMessagePage(channelId, limit, cursor);
+    allFetchedMessages.push(...messages);
+
+    if (lastDigestThreadTimestamp && messages.some(m => m.ts === lastDigestThreadTimestamp)) {
+      break;
+    }
+
+    if (!nextCursor) break;
+    cursor = nextCursor;
+  }
+
+  console.info(`Fetched ${allFetchedMessages.length} messages across pages`);
+
+  const allFetchedTs = new Set(allFetchedMessages.map(m => m.ts));
+  const postDigestMessages = lastDigestThreadTimestamp
+    ? allFetchedMessages.filter(m => parseFloat(m.ts) > parseFloat(lastDigestThreadTimestamp))
+    : [...allFetchedMessages];
+
+  // Source 2: previously-tracked unresolved messages not seen in Source 1
+  const source2Messages = [];
+  if (trackUnresolved) {
+    for (const ts of unresolvedMessageTimestamps) {
+      if (allFetchedTs.has(ts)) continue;
+      const message = await getMessageByTimestamp(channelId, ts);
+      if (message) {
+        source2Messages.push(message);
+      }
+    }
+  }
+
+  // Merge Source 1 post-digest + Source 2, deduplicate by ts, sort ascending
+  const merged = [...postDigestMessages, ...source2Messages];
+  const deduplicated = [...new Map(merged.map(m => [m.ts, m])).values()];
+  deduplicated.sort((a, b) => parseFloat(a.ts) - parseFloat(b.ts));
+
+  console.info(`Processing ${deduplicated.length} messages`);
+  return deduplicated;
 }
 
 export async function getAggregateStatus(pullRequests) {

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -81,16 +81,22 @@ export async function collectMessages(channelId, channelState, limit, maxPages, 
   const allFetchedMessages = [];
   let cursor = undefined;
 
+  let digestFound = false;
   for (let page = 0; page < maxPages; page++) {
     const { messages, nextCursor } = await getMessagePage(channelId, limit, cursor);
     allFetchedMessages.push(...messages);
 
     if (lastDigestThreadTimestamp && messages.some(m => m.ts === lastDigestThreadTimestamp)) {
+      digestFound = true;
       break;
     }
 
     if (!nextCursor) break;
     cursor = nextCursor;
+  }
+
+  if (lastDigestThreadTimestamp && !digestFound) {
+    console.warn(`Reached maxPages (${maxPages}) without finding last digest anchor for channel ${channelId}. Some messages may be missed. Consider increasing maxPages.`);
   }
 
   console.info(`Fetched ${allFetchedMessages.length} messages across pages`);

--- a/src/workflow.test.mjs
+++ b/src/workflow.test.mjs
@@ -293,6 +293,11 @@ describe('shouldProcess', () => {
     const message = { ts: '1.0', text: 'PR link', reactions: [{ name: 'eyes' }] };
     expect(shouldProcess(message, [{}], reactionConfig)).toBe(true);
   });
+
+  it('returns true for a bot message when allowBotMessages is true', () => {
+    const message = { ts: '1.0', text: 'PR link', bot_id: 'B123' };
+    expect(shouldProcess(message, [{}], reactionConfig, true)).toBe(true);
+  });
 });
 
 describe('getAggregateStatus', () => {

--- a/src/workflow.test.mjs
+++ b/src/workflow.test.mjs
@@ -1,0 +1,85 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+vi.mock('./slack.mjs', () => ({
+  getMessagePage: vi.fn(),
+  getMessageByTimestamp: vi.fn(),
+  getPermalink: vi.fn(),
+}));
+vi.mock('./github.mjs', () => ({
+  getPullRequestStatus: vi.fn(),
+  getReviewReactions: vi.fn(),
+}));
+vi.mock('@actions/core', () => ({ getInput: vi.fn() }));
+vi.mock('fs', () => ({ default: { readFileSync: vi.fn(), existsSync: vi.fn() } }));
+
+import { collectMessages } from './workflow.mjs';
+import { getMessagePage, getMessageByTimestamp } from './slack.mjs';
+
+const OLD_TS = '50.0';
+const DIGEST_TS = '100.0';
+const NEW_TS = '150.0';
+
+const oldMessage = { ts: OLD_TS, text: 'old PR' };
+const newMessage = { ts: NEW_TS, text: 'new PR' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('collectMessages', () => {
+  describe('when trackUnresolved is false', () => {
+    it('returns all fetched messages even if they predate the last digest', async () => {
+      // Slack returns newest-first; both messages are in the first page
+      getMessagePage.mockResolvedValueOnce({
+        messages: [newMessage, oldMessage],
+        nextCursor: null,
+      });
+
+      const channelState = {
+        lastDigestThreadTimestamp: DIGEST_TS,
+        unresolvedMessageTimestamps: [],
+      };
+
+      const result = await collectMessages('C123', channelState, 50, 1, false);
+
+      // Both messages should be included — digest timestamp must NOT be used as a filter
+      expect(result).toEqual([oldMessage, newMessage]);
+    });
+
+    it('does not individually fetch previously-tracked message timestamps', async () => {
+      getMessagePage.mockResolvedValueOnce({ messages: [newMessage], nextCursor: null });
+
+      const channelState = {
+        lastDigestThreadTimestamp: DIGEST_TS,
+        unresolvedMessageTimestamps: [OLD_TS],
+      };
+
+      await collectMessages('C123', channelState, 50, 1, false);
+
+      expect(getMessageByTimestamp).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when trackUnresolved is true', () => {
+    it('returns only post-digest paginated messages plus individually-tracked older messages', async () => {
+      const digestMessage = { ts: DIGEST_TS, text: 'digest' };
+      const trackedMessage = { ts: '25.0', text: 'tracked old' };
+
+      getMessagePage.mockResolvedValueOnce({
+        messages: [newMessage, oldMessage, digestMessage],
+        nextCursor: null,
+      });
+      getMessageByTimestamp.mockResolvedValueOnce(trackedMessage);
+
+      const channelState = {
+        lastDigestThreadTimestamp: DIGEST_TS,
+        unresolvedMessageTimestamps: ['25.0'],
+      };
+
+      const result = await collectMessages('C123', channelState, 50, 1, true);
+
+      // Only post-digest from pagination + individually tracked (sorted ascending)
+      expect(result).toEqual([trackedMessage, newMessage]);
+    });
+  });
+});

--- a/src/workflow.test.mjs
+++ b/src/workflow.test.mjs
@@ -12,8 +12,11 @@ vi.mock('./github.mjs', () => ({
 vi.mock('@actions/core', () => ({ getInput: vi.fn() }));
 vi.mock('fs', () => ({ default: { readFileSync: vi.fn(), existsSync: vi.fn() } }));
 
-import { collectMessages } from './workflow.mjs';
-import { getMessagePage, getMessageByTimestamp } from './slack.mjs';
+import { collectMessages, shouldProcess, getAggregateStatus, buildPrMessage, getConfig } from './workflow.mjs';
+import { getMessagePage, getMessageByTimestamp, getPermalink } from './slack.mjs';
+import { getPullRequestStatus, getReviewReactions } from './github.mjs';
+import { getInput } from '@actions/core';
+import fs from 'fs';
 
 const OLD_TS = '50.0';
 const DIGEST_TS = '100.0';
@@ -24,6 +27,81 @@ const newMessage = { ts: NEW_TS, text: 'new PR' };
 
 beforeEach(() => {
   vi.clearAllMocks();
+});
+
+describe('getConfig', () => {
+  beforeEach(() => {
+    getInput.mockReturnValue('config.json');
+  });
+
+  it('applies default values to channel config when fields are omitted', () => {
+    fs.readFileSync.mockReturnValue(JSON.stringify({
+      channels: { ch1: { channelId: 'C123' } },
+    }));
+
+    const { channelConfig } = getConfig();
+
+    expect(channelConfig[0]).toMatchObject({
+      channelId: 'C123',
+      limit: 50,
+      maxPages: 1,
+      trackUnresolved: false,
+      disableReactionCopying: false,
+    });
+  });
+
+  it('applies default emoji values to reaction config when fields are omitted', () => {
+    fs.readFileSync.mockReturnValue(JSON.stringify({ channels: {} }));
+
+    const { reactionConfig } = getConfig();
+
+    expect(reactionConfig).toMatchObject({
+      approved: ['approved'],
+      merged: ['merged'],
+      closed: ['closed'],
+      changesRequested: ['changesRequested'],
+    });
+  });
+
+  it('uses custom emoji values when provided in the config file', () => {
+    fs.readFileSync.mockReturnValue(JSON.stringify({
+      reactions: { approved: ['thumbsup'], merged: ['white_check_mark'] },
+      channels: {},
+    }));
+
+    const { reactionConfig } = getConfig();
+
+    expect(reactionConfig.approved).toEqual(['thumbsup']);
+    expect(reactionConfig.merged).toEqual(['white_check_mark']);
+  });
+
+  it('filters out channels that have no channelId', () => {
+    fs.readFileSync.mockReturnValue(JSON.stringify({
+      channels: {
+        ch1: { channelId: 'C123' },
+        ch2: { limit: 10 },
+      },
+    }));
+
+    const { channelConfig } = getConfig();
+
+    expect(channelConfig).toHaveLength(1);
+    expect(channelConfig[0].channelId).toBe('C123');
+  });
+
+  it('filters out channels that are marked as disabled', () => {
+    fs.readFileSync.mockReturnValue(JSON.stringify({
+      channels: {
+        ch1: { channelId: 'C123', disabled: true },
+        ch2: { channelId: 'C456' },
+      },
+    }));
+
+    const { channelConfig } = getConfig();
+
+    expect(channelConfig).toHaveLength(1);
+    expect(channelConfig[0].channelId).toBe('C456');
+  });
 });
 
 describe('collectMessages', () => {
@@ -81,5 +159,207 @@ describe('collectMessages', () => {
       // Only post-digest from pagination + individually tracked (sorted ascending)
       expect(result).toEqual([trackedMessage, newMessage]);
     });
+
+    it('fetches additional pages until the digest anchor is found', async () => {
+      const page1Messages = [{ ts: '200.0' }, { ts: '180.0' }];
+      const page2Messages = [{ ts: '120.0' }, { ts: DIGEST_TS }];
+
+      getMessagePage
+        .mockResolvedValueOnce({ messages: page1Messages, nextCursor: 'cursor1' })
+        .mockResolvedValueOnce({ messages: page2Messages, nextCursor: null });
+
+      const channelState = {
+        lastDigestThreadTimestamp: DIGEST_TS,
+        unresolvedMessageTimestamps: [],
+      };
+
+      const result = await collectMessages('C123', channelState, 50, 2, true);
+
+      // Post-digest messages sorted ascending (ts > DIGEST_TS)
+      expect(result).toEqual([{ ts: '120.0' }, { ts: '180.0' }, { ts: '200.0' }]);
+    });
+
+    it('stops paginating once the digest anchor is found', async () => {
+      getMessagePage.mockResolvedValueOnce({
+        messages: [newMessage, { ts: DIGEST_TS }],
+        nextCursor: 'cursor1', // cursor exists but should not be followed
+      });
+
+      const channelState = {
+        lastDigestThreadTimestamp: DIGEST_TS,
+        unresolvedMessageTimestamps: [],
+      };
+
+      await collectMessages('C123', channelState, 50, 5, true);
+
+      expect(getMessagePage).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips individually fetching timestamps already retrieved via pagination', async () => {
+      getMessagePage.mockResolvedValueOnce({
+        messages: [newMessage, oldMessage, { ts: DIGEST_TS }],
+        nextCursor: null,
+      });
+
+      const channelState = {
+        lastDigestThreadTimestamp: DIGEST_TS,
+        unresolvedMessageTimestamps: [OLD_TS], // OLD_TS is already in the paginated results
+      };
+
+      await collectMessages('C123', channelState, 50, 1, true);
+
+      expect(getMessageByTimestamp).not.toHaveBeenCalled();
+    });
+
+    it('excludes tracked messages that have since been deleted', async () => {
+      getMessagePage.mockResolvedValueOnce({
+        messages: [newMessage, { ts: DIGEST_TS }],
+        nextCursor: null,
+      });
+      getMessageByTimestamp.mockResolvedValueOnce(null); // message was deleted
+
+      const channelState = {
+        lastDigestThreadTimestamp: DIGEST_TS,
+        unresolvedMessageTimestamps: ['25.0'],
+      };
+
+      const result = await collectMessages('C123', channelState, 50, 1, true);
+
+      expect(result).toEqual([newMessage]);
+    });
+
+    it('returns all fetched messages when there is no previous digest', async () => {
+      getMessagePage.mockResolvedValueOnce({
+        messages: [newMessage, oldMessage],
+        nextCursor: null,
+      });
+
+      const channelState = {
+        lastDigestThreadTimestamp: null,
+        unresolvedMessageTimestamps: [],
+      };
+
+      const result = await collectMessages('C123', channelState, 50, 1, true);
+
+      expect(result).toEqual([oldMessage, newMessage]);
+    });
+  });
+});
+
+describe('shouldProcess', () => {
+  const reactionConfig = {
+    approved: ['approved'],
+    merged: ['white-check-mark'],
+    closed: ['x'],
+    changesRequested: ['changes-requested'],
+  };
+
+  it('returns false when the message has no pull requests', () => {
+    const message = { ts: '1.0', text: 'no PRs here' };
+    expect(shouldProcess(message, [], reactionConfig)).toBe(false);
+  });
+
+  it('returns false when the message was posted by a bot', () => {
+    const message = { ts: '1.0', text: 'PR link', bot_id: 'B123' };
+    expect(shouldProcess(message, [{}], reactionConfig)).toBe(false);
+  });
+
+  it('returns false when the message already has a merged reaction', () => {
+    const message = { ts: '1.0', text: 'PR link', reactions: [{ name: 'white-check-mark' }] };
+    expect(shouldProcess(message, [{}], reactionConfig)).toBe(false);
+  });
+
+  it('returns false when the message already has a closed reaction', () => {
+    const message = { ts: '1.0', text: 'PR link', reactions: [{ name: 'x' }] };
+    expect(shouldProcess(message, [{}], reactionConfig)).toBe(false);
+  });
+
+  it('returns true for a message with a PR and no resolved reactions', () => {
+    const message = { ts: '1.0', text: 'PR link' };
+    expect(shouldProcess(message, [{}], reactionConfig)).toBe(true);
+  });
+
+  it('returns true when the message only has unrelated reactions', () => {
+    const message = { ts: '1.0', text: 'PR link', reactions: [{ name: 'eyes' }] };
+    expect(shouldProcess(message, [{}], reactionConfig)).toBe(true);
+  });
+});
+
+describe('getAggregateStatus', () => {
+  it('returns "open" when any PR is open', async () => {
+    getPullRequestStatus
+      .mockResolvedValueOnce('open')
+      .mockResolvedValueOnce('merged');
+    expect(await getAggregateStatus([{}, {}])).toBe('open');
+  });
+
+  it('returns "merged" when all PRs are merged', async () => {
+    getPullRequestStatus.mockResolvedValue('merged');
+    expect(await getAggregateStatus([{}])).toBe('merged');
+  });
+
+  it('returns "closed" when all PRs are closed', async () => {
+    getPullRequestStatus.mockResolvedValue('closed');
+    expect(await getAggregateStatus([{}])).toBe('closed');
+  });
+
+  it('returns "merged" when some PRs are merged and others are closed', async () => {
+    getPullRequestStatus
+      .mockResolvedValueOnce('merged')
+      .mockResolvedValueOnce('closed');
+    expect(await getAggregateStatus([{}, {}])).toBe('merged');
+  });
+});
+
+describe('buildPrMessage', () => {
+  const pr = { owner: 'org', repo: 'repo', pull_number: '1' };
+  const reactionConfig = {
+    approved: ['approved'],
+    changesRequested: ['changes-requested'],
+    merged: ['merged'],
+    closed: ['closed'],
+  };
+
+  beforeEach(() => {
+    getPermalink.mockResolvedValue('https://slack.com/archives/C123/p100');
+    getReviewReactions.mockResolvedValue([]);
+  });
+
+  it('returns the Slack permalink for the message', async () => {
+    const message = { ts: '1.0' };
+    const result = await buildPrMessage('C123', message, pr, reactionConfig, true);
+    expect(result.permalink).toBe('https://slack.com/archives/C123/p100');
+  });
+
+  it('includes existing message reactions when disableReactionCopying is false', async () => {
+    const message = { ts: '1.0', reactions: [{ name: 'eyes' }, { name: 'rocket' }] };
+    const result = await buildPrMessage('C123', message, pr, reactionConfig, false);
+    expect(result.reactions).toEqual(expect.arrayContaining(['eyes', 'rocket']));
+  });
+
+  it('omits existing message reactions when disableReactionCopying is true', async () => {
+    const message = { ts: '1.0', reactions: [{ name: 'eyes' }] };
+    const result = await buildPrMessage('C123', message, pr, reactionConfig, true);
+    expect(result.reactions).not.toContain('eyes');
+  });
+
+  it('includes reactions derived from GitHub reviews', async () => {
+    getReviewReactions.mockResolvedValue(['approved']);
+    const message = { ts: '1.0' };
+    const result = await buildPrMessage('C123', message, pr, reactionConfig, true);
+    expect(result.reactions).toContain('approved');
+  });
+
+  it('deduplicates reactions that appear in both existing and review sources', async () => {
+    getReviewReactions.mockResolvedValue(['approved']);
+    const message = { ts: '1.0', reactions: [{ name: 'approved' }] };
+    const result = await buildPrMessage('C123', message, pr, reactionConfig, false);
+    expect(result.reactions.filter(r => r === 'approved')).toHaveLength(1);
+  });
+
+  it('returns an empty reactions list when the message has no reactions and there are no reviews', async () => {
+    const message = { ts: '1.0' };
+    const result = await buildPrMessage('C123', message, pr, reactionConfig, false);
+    expect(result.reactions).toEqual([]);
   });
 });

--- a/src/workflow.test.mjs
+++ b/src/workflow.test.mjs
@@ -102,6 +102,16 @@ describe('getConfig', () => {
     expect(channelConfig).toHaveLength(1);
     expect(channelConfig[0].channelId).toBe('C456');
   });
+
+  it('defaults allowBotMessages to false when omitted from channel config', () => {
+    fs.readFileSync.mockReturnValue(JSON.stringify({
+      channels: { ch1: { channelId: 'C123' } },
+    }));
+
+    const { channelConfig } = getConfig();
+
+    expect(channelConfig[0].allowBotMessages).toBe(false);
+  });
 });
 
 describe('collectMessages', () => {


### PR DESCRIPTION
## Summary

- **Persistent state tracking** (`trackUnresolved`): A new per-channel flag enables tracking of unresolved PR messages across runs. State is persisted to a JSON file (`state-file` input) and committed back to the repo automatically.
- **Paginated Slack history** (`limit`, `maxPages`): Message collection now pages through channel history up to a configurable depth, stopping early when the previous digest thread is found.
- **Per-channel `allowBotMessages` flag** (default `false`): When enabled, bot-posted Slack messages are eligible for PR tracking instead of being unconditionally skipped.
- **`disableReactionCopying` flag**: Opt out of copying existing message reactions onto digest entries.
- **`skipDigest` action input**: Run PR status checks and reactions without posting the open-PR digest thread.
- Comprehensive Vitest unit test suite added across `workflow`, `index`, and `github` modules.

## New config options

```json
{
  "channels": {
    "my-channel": {
      "channelId": "C123ABC",
      "trackUnresolved": true,
      "allowBotMessages": false,
      "disableReactionCopying": false,
      "limit": 50,
      "maxPages": 1
    }
  }
}
```

## New action inputs

| Input | Default | Description |
|---|---|---|
| `state-file` | `./pr-channel-state.json` | Path for persisting unresolved PR state between runs |
| `skip-digest` | `false` | Skip posting the open-PR digest thread |

## Test Plan

- [ ] All 46 unit tests pass (`npm test`)
- [ ] With `trackUnresolved: true`, state file is committed after each run and previously-tracked messages are re-fetched
- [ ] With `trackUnresolved: false`, no state file is written or committed
- [ ] With `allowBotMessages: true`, bot-posted PR links appear in the digest
- [ ] With `allowBotMessages: false` (default), bot messages are skipped as before