### PR TITLE
feat: clean up ChannelConfig API for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The PR Channel Slackbot action does the following steps for each configured Slac
    - The action adds a response within the thread for each message containing a link to an open pull request.
 
 5. **Copy Reactions**:
-   - Any reactions present on the original message are copied over to the response within the thread, ensuring continuity and visibility of feedback. This can be disabled per-channel via `disableReactionCopying`.
+   - Reactions are NOT copied by default. Reaction copying can be enabled per-channel via `enableReactionCopying`.
 
 ### Example Output
 ![alt text](images/example.png)
@@ -235,8 +235,7 @@ Example `pr_channel_slackbot_config.json`:
         },
         "project-bar-prs": {
             "channelId": "C654321",
-            "disableReactionCopying": true,
-            "allowBotMessages": true
+            "enableReactionCopying": true
         },
         "project-baz-prs": {
             "channelId": "C987654",
@@ -268,10 +267,32 @@ Each channel configuration can have the following fields:
     > [!NOTE]
     > It is recommended that you use a channel that is dedicated for pull requests to separate requests for reviews from other development-related conversations.  If your team is consistently reviewing pull requests, a large limit should not be required.
 * `maxPages` - (optional - default `1`) the maximum number of pages of Slack history to fetch. Increase this if your channel is high-volume and PRs may fall outside a single page. When `trackUnresolved` is enabled, pagination stops early once the previous digest thread is found.
-* `trackUnresolved` - (optional - default `false`) when `true`, the bot persists unresolved PR message timestamps and the last digest thread timestamp to the state file between runs. This ensures long-running PRs are never dropped from the digest even if they scroll outside the pagination window. Requires the `state-file` action input and `contents: write` workflow permission.
-* `allowBotMessages` - (optional - default `false`) when `true`, messages posted by bots are eligible for PR tracking. By default, bot messages are skipped.
+* `trackUnresolved` - (optional - default `true`) when `true`, the bot persists unresolved PR message timestamps and the last digest thread timestamp to the state file between runs. This ensures long-running PRs are never dropped from the digest even if they scroll outside the pagination window. Requires the `state-file` action input and `contents: write` workflow permission.
+* `allowBotMessages` - (optional - default `true`) when `true`, messages posted by bots are eligible for PR tracking. Set to `false` to skip bot messages.
 * `disabled` - (optional - default `false`) if you wish to disable a channel without completely removing it, you can mark it as disabled.
-* `disableReactionCopying` - (optional - default `false`) when `true`, reactions from the original message are not copied to the digest thread entry.
+* `enableReactionCopying` - (optional - default `false`) when `true`, reactions from the original message are copied to the digest thread entry.
+
+## Migrating from v1
+
+### `disableReactionCopying` → `enableReactionCopying`
+
+The `disableReactionCopying` field has been replaced by `enableReactionCopying` with inverted semantics. Reaction copying is now **opt-in** (disabled by default).
+
+- Had `"disableReactionCopying": true` → replace with `"enableReactionCopying": false` (or simply omit it — no behavior change; reactions still not copied)
+- Had `"disableReactionCopying": false` or omitted → add `"enableReactionCopying": true` if you want reactions copied (this was previously the default; now opt-in)
+
+### `trackUnresolved` now defaults to `true`
+
+Previously this field didn't exist and unresolved tracking was always off. In v2 it is on by default.
+
+- Requires adding `contents: write` permission to your workflow job AND the workflow actor must be allowed to commit directly to the branch.
+- To restore the old behavior, explicitly set `"trackUnresolved": false` on each channel.
+
+### `allowBotMessages` now defaults to `true`
+
+Previously bot messages were always blocked. In v2 they are included by default.
+
+- To restore the old behavior, explicitly set `"allowBotMessages": false` on each channel.
 
 ## License
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42381,7 +42381,7 @@ async function run() {
 
     const state = (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .loadState */ .jw)(stateFile);
 
-    for (let { channelId, limit, maxPages, trackUnresolved, disableReactionCopying, allowBotMessages } of channelConfig) {
+    for (let { channelId, limit, maxPages, trackUnresolved, enableReactionCopying, allowBotMessages } of channelConfig) {
       const channelState = (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .getChannelState */ .iJ)(state, channelId);
       const messages = await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .collectMessages */ .$I)(channelId, channelState, limit, maxPages, trackUnresolved);
 
@@ -42406,7 +42406,7 @@ async function run() {
 
         if (!skipDigest) {
           messagesForDigest.push(
-            await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .buildPrMessage */ .wB)(channelId, message, pullRequests[0], reactionConfig, disableReactionCopying)
+            await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .buildPrMessage */ .wB)(channelId, message, pullRequests[0], reactionConfig, enableReactionCopying)
           );
         }
       }
@@ -42707,7 +42707,7 @@ function distinct(array) {
  * @property {number} limit
  * @property {number} maxPages
  * @property {boolean} trackUnresolved
- * @property {boolean} disableReactionCopying
+ * @property {boolean} enableReactionCopying
  * @property {boolean} allowBotMessages
  */
 /**
@@ -42737,9 +42737,9 @@ function getConfig() {
       ...it,
       limit: it.limit ?? 50,
       maxPages: it.maxPages ?? 1,
-      trackUnresolved: it.trackUnresolved ?? false,
-      disableReactionCopying: it.disableReactionCopying ?? false,
-      allowBotMessages: it.allowBotMessages ?? false
+      trackUnresolved: it.trackUnresolved ?? true,
+      enableReactionCopying: it.enableReactionCopying ?? false,
+      allowBotMessages: it.allowBotMessages ?? true
     }))
     .filter(it => it.channelId && !it.disabled);
 
@@ -42903,13 +42903,13 @@ function isResolved(message, reactionConfig) {
  * @param {ChannelConfig} channelConfig
  * @returns {Promise<PrMessage>}
  */
-async function buildPrMessage(channelId, message, pullRequest, reactionConfig, disableReactionCopying) {
+async function buildPrMessage(channelId, message, pullRequest, reactionConfig, enableReactionCopying) {
   /** @type {Array<string>} */
-  const existingReactions = disableReactionCopying
-    ? []
-    : (message.reactions ?? [])
+  const existingReactions = enableReactionCopying
+    ? (message.reactions ?? [])
       .map(reaction => reaction.name)
-      .filter(it => it);
+      .filter(it => it)
+    : [];
   const reviewReactions = await (0,github/* getReviewReactions */.zp)(pullRequest, reactionConfig);
   const allReactions = distinct([...existingReactions, ...reviewReactions]);
   const permalink = await (0,slack/* getPermalink */.t5)(channelId, message.ts);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pr-channel-slackbot",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Simple Slackbot for managing a PR channel",
   "main": "dist/index.mjs",
   "scripts": {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -12,7 +12,7 @@ export async function run() {
 
     const state = loadState(stateFile);
 
-    for (let { channelId, limit, maxPages, trackUnresolved, disableReactionCopying, allowBotMessages } of channelConfig) {
+    for (let { channelId, limit, maxPages, trackUnresolved, enableReactionCopying, allowBotMessages } of channelConfig) {
       const channelState = getChannelState(state, channelId);
       const messages = await collectMessages(channelId, channelState, limit, maxPages, trackUnresolved);
 
@@ -37,7 +37,7 @@ export async function run() {
 
         if (!skipDigest) {
           messagesForDigest.push(
-            await buildPrMessage(channelId, message, pullRequests[0], reactionConfig, disableReactionCopying)
+            await buildPrMessage(channelId, message, pullRequests[0], reactionConfig, enableReactionCopying)
           );
         }
       }

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -21,7 +21,7 @@ import { distinct } from './utils.mjs';
  * @property {number} limit
  * @property {number} maxPages
  * @property {boolean} trackUnresolved
- * @property {boolean} disableReactionCopying
+ * @property {boolean} enableReactionCopying
  * @property {boolean} allowBotMessages
  */
 /**
@@ -51,9 +51,9 @@ export function getConfig() {
       ...it,
       limit: it.limit ?? 50,
       maxPages: it.maxPages ?? 1,
-      trackUnresolved: it.trackUnresolved ?? false,
-      disableReactionCopying: it.disableReactionCopying ?? false,
-      allowBotMessages: it.allowBotMessages ?? false
+      trackUnresolved: it.trackUnresolved ?? true,
+      enableReactionCopying: it.enableReactionCopying ?? false,
+      allowBotMessages: it.allowBotMessages ?? true
     }))
     .filter(it => it.channelId && !it.disabled);
 
@@ -217,13 +217,13 @@ function isResolved(message, reactionConfig) {
  * @param {ChannelConfig} channelConfig
  * @returns {Promise<PrMessage>}
  */
-export async function buildPrMessage(channelId, message, pullRequest, reactionConfig, disableReactionCopying) {
+export async function buildPrMessage(channelId, message, pullRequest, reactionConfig, enableReactionCopying) {
   /** @type {Array<string>} */
-  const existingReactions = disableReactionCopying
-    ? []
-    : (message.reactions ?? [])
+  const existingReactions = enableReactionCopying
+    ? (message.reactions ?? [])
       .map(reaction => reaction.name)
-      .filter(it => it);
+      .filter(it => it)
+    : [];
   const reviewReactions = await getReviewReactions(pullRequest, reactionConfig);
   const allReactions = distinct([...existingReactions, ...reviewReactions]);
   const permalink = await getPermalink(channelId, message.ts);

--- a/src/workflow.test.mjs
+++ b/src/workflow.test.mjs
@@ -45,8 +45,8 @@ describe('getConfig', () => {
       channelId: 'C123',
       limit: 50,
       maxPages: 1,
-      trackUnresolved: false,
-      disableReactionCopying: false,
+      trackUnresolved: true,
+      enableReactionCopying: false,
     });
   });
 
@@ -103,14 +103,14 @@ describe('getConfig', () => {
     expect(channelConfig[0].channelId).toBe('C456');
   });
 
-  it('defaults allowBotMessages to false when omitted from channel config', () => {
+  it('defaults allowBotMessages to true when omitted from channel config', () => {
     fs.readFileSync.mockReturnValue(JSON.stringify({
       channels: { ch1: { channelId: 'C123' } },
     }));
 
     const { channelConfig } = getConfig();
 
-    expect(channelConfig[0].allowBotMessages).toBe(false);
+    expect(channelConfig[0].allowBotMessages).toBe(true);
   });
 });
 
@@ -342,33 +342,33 @@ describe('buildPrMessage', () => {
 
   it('returns the Slack permalink for the message', async () => {
     const message = { ts: '1.0' };
-    const result = await buildPrMessage('C123', message, pr, reactionConfig, true);
+    const result = await buildPrMessage('C123', message, pr, reactionConfig, false);
     expect(result.permalink).toBe('https://slack.com/archives/C123/p100');
   });
 
-  it('includes existing message reactions when disableReactionCopying is false', async () => {
+  it('includes existing message reactions when enableReactionCopying is true', async () => {
     const message = { ts: '1.0', reactions: [{ name: 'eyes' }, { name: 'rocket' }] };
-    const result = await buildPrMessage('C123', message, pr, reactionConfig, false);
+    const result = await buildPrMessage('C123', message, pr, reactionConfig, true);
     expect(result.reactions).toEqual(expect.arrayContaining(['eyes', 'rocket']));
   });
 
-  it('omits existing message reactions when disableReactionCopying is true', async () => {
+  it('omits existing message reactions when enableReactionCopying is false', async () => {
     const message = { ts: '1.0', reactions: [{ name: 'eyes' }] };
-    const result = await buildPrMessage('C123', message, pr, reactionConfig, true);
+    const result = await buildPrMessage('C123', message, pr, reactionConfig, false);
     expect(result.reactions).not.toContain('eyes');
   });
 
   it('includes reactions derived from GitHub reviews', async () => {
     getReviewReactions.mockResolvedValue(['approved']);
     const message = { ts: '1.0' };
-    const result = await buildPrMessage('C123', message, pr, reactionConfig, true);
+    const result = await buildPrMessage('C123', message, pr, reactionConfig, false);
     expect(result.reactions).toContain('approved');
   });
 
   it('deduplicates reactions that appear in both existing and review sources', async () => {
     getReviewReactions.mockResolvedValue(['approved']);
     const message = { ts: '1.0', reactions: [{ name: 'approved' }] };
-    const result = await buildPrMessage('C123', message, pr, reactionConfig, false);
+    const result = await buildPrMessage('C123', message, pr, reactionConfig, true);
     expect(result.reactions.filter(r => r === 'approved')).toHaveLength(1);
   });
 


### PR DESCRIPTION
## Summary

- Rename `disableReactionCopying` → `enableReactionCopying` (inverted logic, now opt-in; reactions off by default)
- Default `trackUnresolved` to `true` (was `false`)
- Default `allowBotMessages` to `true` (was `false`)
- Bump `package.json` version to `2.0.0`
- Add "Migrating from v1" section to README covering all three breaking changes

## Test plan

- [ ] All existing tests pass (`npm test`)
- [ ] Review "Migrating from v1" section in README for clarity
- [ ] After merge, create and push `v2` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)