### PR TITLE
feat: mirror reactions to digest thread and mark superseded digests

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ The PR Channel Slackbot action does the following steps for each configured Slac
 2. **Check pull request Status**:
    - For each pull request link found:
      - If the message is already marked with a `closed` or `merged` reaction, it is skipped.
-     - Query GitHub for the status of the pull request. If the pull request is merged or closed, the corresponding reaction is added to the message and the action moves on to the next message.
+     - Query GitHub for the status of the pull request. If the pull request is merged or closed, the corresponding reaction is added to the message. If the message also has an entry in the previous digest thread, the same reaction is added there as well. The action then moves on to the next message.
      - If the pull request is still open, the retrieve the review status from GitHub. If changes are requested, the `changesRequested` reaction is added to the message. Otherwise, if there are approvals, the `approved` reaction is added.
 
 3. **Create New Thread**:
-   - After processing all relevant messages, the action creates a new thread in the pull request channel. This step (and the next two) can be skipped by setting `skip-digest: true`.
+   - After processing all relevant messages, the action creates a new thread in the pull request channel. If a previous digest thread exists, a reply is posted to it indicating that a new digest has been posted, with a link to the new one. This step (and the next two) can be skipped by setting `skip-digest: true`.
 
 4. **Add Responses**:
    - The action adds a response within the thread for each message containing a link to an open pull request.

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42384,6 +42384,7 @@ async function run() {
     for (let { channelId, limit, maxPages, trackUnresolved, enableReactionCopying, allowBotMessages } of channelConfig) {
       const channelState = (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .getChannelState */ .iJ)(state, channelId);
       const messages = await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .collectMessages */ .$I)(channelId, channelState, limit, maxPages, trackUnresolved);
+      const digestThreadMap = await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .buildDigestThreadMap */ .XW)(channelId, channelState.lastDigestThreadTimestamp);
 
       const messagesForDigest = [];
       const unresolvedTimestamps = [];
@@ -42398,7 +42399,12 @@ async function run() {
         const status = await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .getAggregateStatus */ .di)(pullRequests);
         if (['closed', 'merged'].includes(status)) {
           console.debug(`RESOLVING: ${message.ts} is ${status}`);
-          await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .addReaction */ .rU)(channelId, message.ts, reactionConfig[status][0]);
+          const reaction = reactionConfig[status][0];
+          await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .addReaction */ .rU)(channelId, message.ts, reaction);
+          const digestMessageTs = digestThreadMap.get(message.ts);
+          if (digestMessageTs) {
+            await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .addReaction */ .rU)(channelId, digestMessageTs, reaction);
+          }
           continue;
         }
 
@@ -42411,9 +42417,15 @@ async function run() {
         }
       }
 
-      const digestThreadTimestamp = (skipDigest
-        ? channelState.lastDigestThreadTimestamp
-        : await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .postOpenPrs */ .JZ)(channelId, messagesForDigest));
+      let digestThreadTimestamp;
+      if (skipDigest) {
+        digestThreadTimestamp = channelState.lastDigestThreadTimestamp;
+      } else {
+        digestThreadTimestamp = await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .postOpenPrs */ .JZ)(channelId, messagesForDigest);
+        if (channelState.lastDigestThreadTimestamp) {
+          await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .markThreadSuperseded */ .n6)(channelId, channelState.lastDigestThreadTimestamp, digestThreadTimestamp);
+        }
+      }
 
       if (trackUnresolved) {
         state[channelId] = {
@@ -42446,6 +42458,8 @@ __webpack_async_result__();
 /* harmony export */   "D2": () => (/* binding */ getMessageByTimestamp),
 /* harmony export */   "JZ": () => (/* binding */ postOpenPrs),
 /* harmony export */   "OT": () => (/* binding */ getMessagePage),
+/* harmony export */   "Um": () => (/* binding */ getThreadReplies),
+/* harmony export */   "n6": () => (/* binding */ markThreadSuperseded),
 /* harmony export */   "rU": () => (/* binding */ addReaction),
 /* harmony export */   "t5": () => (/* binding */ getPermalink)
 /* harmony export */ });
@@ -42511,6 +42525,20 @@ function addReaction(channelId, messageTs, reaction) {
   });
 }
 
+/**
+ * Fetch all reply messages in a thread.
+ * @param {string} channelId
+ * @param {string} threadTs
+ * @returns {Promise<SlackMessage[]>}
+ */
+async function getThreadReplies(channelId, threadTs) {
+  const response = await slackClient().conversations.replies({
+    channel: channelId,
+    ts: threadTs
+  });
+  return response.messages ?? [];
+}
+
 function getPermalink(channelId, messageTs) {
   return slackClient().chat.getPermalink({
     channel: channelId,
@@ -42556,6 +42584,15 @@ async function postPrMessage(channelId, threadId, message) {
     channel: channelId,
     thread_ts: threadId,
     text: `<${message.permalink}|Original message>`,
+  });
+}
+
+async function markThreadSuperseded(channelId, oldThreadTs, newThreadTs) {
+  const permalink = await getPermalink(channelId, newThreadTs);
+  return slackClient().chat.postMessage({
+    channel: channelId,
+    thread_ts: oldThreadTs,
+    text: `A new digest has been posted. <${permalink}|View it here>.`
   });
 }
 
@@ -42659,6 +42696,7 @@ function saveState(stateFile, state) {
 
 // EXPORTS
 __nccwpck_require__.d(__webpack_exports__, {
+  "XW": () => (/* binding */ buildDigestThreadMap),
   "wB": () => (/* binding */ buildPrMessage),
   "$I": () => (/* binding */ collectMessages),
   "di": () => (/* binding */ getAggregateStatus),
@@ -42841,6 +42879,47 @@ async function collectMessages(channelId, channelState, limit, maxPages, trackUn
 
   console.info(`Processing ${result.length} messages`);
   return result;
+}
+
+/**
+ * Convert a Slack permalink URL to a message timestamp.
+ * Permalink format: https://workspace.slack.com/archives/CHANNEL/pTIMESTAMP
+ * where TIMESTAMP is the ts with the decimal removed (10 sec digits + 6 microsecond digits).
+ * @param {string} url
+ * @returns {string|null}
+ */
+function parseTsFromPermalink(url) {
+  const match = url.match(/\/p(\d{16})/);
+  if (!match) return null;
+  const digits = match[1];
+  return `${digits.slice(0, 10)}.${digits.slice(10)}`;
+}
+
+/**
+ * Build a map from original message ts to digest thread reply ts by fetching
+ * the thread under lastDigestThreadTimestamp and parsing each bot reply's
+ * "Original message" link.
+ *
+ * @param {string} channelId
+ * @param {string|null} lastDigestThreadTimestamp
+ * @returns {Promise<Map<string, string>>} Map from originalTs to digestThreadReplyTs
+ */
+async function buildDigestThreadMap(channelId, lastDigestThreadTimestamp) {
+  if (!lastDigestThreadTimestamp) return new Map();
+
+  const threadMessages = await (0,slack/* getThreadReplies */.Um)(channelId, lastDigestThreadTimestamp);
+  const map = new Map();
+
+  for (const msg of threadMessages) {
+    const match = msg.text?.match(/<([^|>]+)\|Original message>/);
+    if (!match) continue;
+    const originalTs = parseTsFromPermalink(match[1]);
+    if (originalTs) {
+      map.set(originalTs, msg.ts);
+    }
+  }
+
+  return map;
 }
 
 async function getAggregateStatus(pullRequests) {

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -42526,17 +42526,30 @@ function addReaction(channelId, messageTs, reaction) {
 }
 
 /**
- * Fetch all reply messages in a thread.
+ * Fetch all reply messages in a thread, handling Slack pagination.
  * @param {string} channelId
  * @param {string} threadTs
  * @returns {Promise<SlackMessage[]>}
  */
 async function getThreadReplies(channelId, threadTs) {
-  const response = await slackClient().conversations.replies({
-    channel: channelId,
-    ts: threadTs
-  });
-  return response.messages ?? [];
+  /** @type {SlackMessage[]} */
+  const messages = [];
+  let cursor = undefined;
+
+  while (true) {
+    const response = await slackClient().conversations.replies({
+      channel: channelId,
+      ts: threadTs,
+      cursor
+    });
+
+    messages.push(...(response.messages ?? []));
+
+    cursor = response.response_metadata?.next_cursor || undefined;
+    if (!cursor) break;
+  }
+
+  return messages;
 }
 
 function getPermalink(channelId, messageTs) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,6 +1,6 @@
 import { getBooleanInput, getInput, setFailed } from "@actions/core";
-import { getConfig, shouldProcess, getAggregateStatus, buildPrMessage, collectMessages } from "./workflow.mjs";
-import { addReaction, postOpenPrs } from "./slack.mjs";
+import { getConfig, shouldProcess, getAggregateStatus, buildPrMessage, collectMessages, buildDigestThreadMap } from "./workflow.mjs";
+import { addReaction, postOpenPrs, markThreadSuperseded } from "./slack.mjs";
 import { extractPullRequests } from "./github.mjs";
 import { loadState, saveState, getChannelState } from "./state.mjs";
 
@@ -15,6 +15,7 @@ export async function run() {
     for (let { channelId, limit, maxPages, trackUnresolved, enableReactionCopying, allowBotMessages } of channelConfig) {
       const channelState = getChannelState(state, channelId);
       const messages = await collectMessages(channelId, channelState, limit, maxPages, trackUnresolved);
+      const digestThreadMap = await buildDigestThreadMap(channelId, channelState.lastDigestThreadTimestamp);
 
       const messagesForDigest = [];
       const unresolvedTimestamps = [];
@@ -29,7 +30,12 @@ export async function run() {
         const status = await getAggregateStatus(pullRequests);
         if (['closed', 'merged'].includes(status)) {
           console.debug(`RESOLVING: ${message.ts} is ${status}`);
-          await addReaction(channelId, message.ts, reactionConfig[status][0]);
+          const reaction = reactionConfig[status][0];
+          await addReaction(channelId, message.ts, reaction);
+          const digestMessageTs = digestThreadMap.get(message.ts);
+          if (digestMessageTs) {
+            await addReaction(channelId, digestMessageTs, reaction);
+          }
           continue;
         }
 
@@ -42,9 +48,15 @@ export async function run() {
         }
       }
 
-      const digestThreadTimestamp = (skipDigest
-        ? channelState.lastDigestThreadTimestamp
-        : await postOpenPrs(channelId, messagesForDigest));
+      let digestThreadTimestamp;
+      if (skipDigest) {
+        digestThreadTimestamp = channelState.lastDigestThreadTimestamp;
+      } else {
+        digestThreadTimestamp = await postOpenPrs(channelId, messagesForDigest);
+        if (channelState.lastDigestThreadTimestamp) {
+          await markThreadSuperseded(channelId, channelState.lastDigestThreadTimestamp, digestThreadTimestamp);
+        }
+      }
 
       if (trackUnresolved) {
         state[channelId] = {

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -13,10 +13,12 @@ vi.mock('./workflow.mjs', () => ({
   shouldProcess: vi.fn(() => false),
   getAggregateStatus: vi.fn(),
   buildPrMessage: vi.fn(),
+  buildDigestThreadMap: vi.fn().mockResolvedValue(new Map()),
 }));
 vi.mock('./slack.mjs', () => ({
   addReaction: vi.fn(),
   postOpenPrs: vi.fn().mockResolvedValue('digest-ts'),
+  markThreadSuperseded: vi.fn().mockResolvedValue(undefined),
 }));
 vi.mock('./github.mjs', () => ({
   extractPullRequests: vi.fn(() => []),
@@ -31,9 +33,9 @@ vi.mock('./state.mjs', () => ({
 }));
 
 import { run } from './index.mjs';
-import { getConfig, collectMessages, shouldProcess, getAggregateStatus, buildPrMessage } from './workflow.mjs';
+import { getConfig, collectMessages, shouldProcess, getAggregateStatus, buildPrMessage, buildDigestThreadMap } from './workflow.mjs';
 import { loadState, saveState, getChannelState } from './state.mjs';
-import { postOpenPrs, addReaction } from './slack.mjs';
+import { postOpenPrs, addReaction, markThreadSuperseded } from './slack.mjs';
 import { extractPullRequests } from './github.mjs';
 import { getBooleanInput, setFailed } from '@actions/core';
 
@@ -46,6 +48,7 @@ beforeEach(() => {
   // Reset these explicitly since vi.clearAllMocks() does not reset mockReturnValue
   getBooleanInput.mockReturnValue(false);
   shouldProcess.mockReturnValue(false);
+  buildDigestThreadMap.mockResolvedValue(new Map());
 });
 
 const BASE_CHANNEL = {
@@ -122,6 +125,24 @@ describe('run()', () => {
 
       expect(addReaction).toHaveBeenCalledWith('C123', PR_MESSAGE.ts, 'x');
     });
+
+    it('also adds the reaction to the digest thread entry when the message appears in the map', async () => {
+      const DIGEST_REPLY_TS = 'digest-reply-ts';
+      buildDigestThreadMap.mockResolvedValue(new Map([[PR_MESSAGE.ts, DIGEST_REPLY_TS]]));
+      getAggregateStatus.mockResolvedValue('merged');
+
+      await run();
+
+      expect(addReaction).toHaveBeenCalledWith('C123', DIGEST_REPLY_TS, 'white-check-mark');
+    });
+
+    it('does not add a second reaction call when the message is not in the digest thread map', async () => {
+      getAggregateStatus.mockResolvedValue('merged');
+
+      await run();
+
+      expect(addReaction).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('when a message has an open PR', () => {
@@ -181,6 +202,47 @@ describe('run()', () => {
 
       const [, savedState] = saveState.mock.calls[0];
       expect(savedState['C123'].lastDigestThreadTimestamp).toBe(PREV_DIGEST_TS);
+    });
+
+    it('does not mark the previous digest as superseded', async () => {
+      await run();
+
+      expect(markThreadSuperseded).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when posting a new digest', () => {
+    beforeEach(() => {
+      getConfig.mockReturnValue({
+        reactionConfig: { merged: ['merged'], closed: ['closed'] },
+        channelConfig: [{ ...BASE_CHANNEL, trackUnresolved: true }],
+      });
+      collectMessages.mockResolvedValue([]);
+    });
+
+    it('marks the previous digest thread as superseded', async () => {
+      const PREV_DIGEST_TS = 'prev-digest-ts';
+      const NEW_DIGEST_TS = 'new-digest-ts';
+      getChannelState.mockReturnValue({
+        unresolvedMessageTimestamps: [],
+        lastDigestThreadTimestamp: PREV_DIGEST_TS,
+      });
+      postOpenPrs.mockResolvedValue(NEW_DIGEST_TS);
+
+      await run();
+
+      expect(markThreadSuperseded).toHaveBeenCalledWith('C123', PREV_DIGEST_TS, NEW_DIGEST_TS);
+    });
+
+    it('does not mark any digest as superseded when there is no previous digest', async () => {
+      getChannelState.mockReturnValue({
+        unresolvedMessageTimestamps: [],
+        lastDigestThreadTimestamp: null,
+      });
+
+      await run();
+
+      expect(markThreadSuperseded).not.toHaveBeenCalled();
     });
   });
 

--- a/src/slack.mjs
+++ b/src/slack.mjs
@@ -58,6 +58,20 @@ export function addReaction(channelId, messageTs, reaction) {
   });
 }
 
+/**
+ * Fetch all reply messages in a thread.
+ * @param {string} channelId
+ * @param {string} threadTs
+ * @returns {Promise<SlackMessage[]>}
+ */
+export async function getThreadReplies(channelId, threadTs) {
+  const response = await slackClient().conversations.replies({
+    channel: channelId,
+    ts: threadTs
+  });
+  return response.messages ?? [];
+}
+
 export function getPermalink(channelId, messageTs) {
   return slackClient().chat.getPermalink({
     channel: channelId,
@@ -103,5 +117,14 @@ async function postPrMessage(channelId, threadId, message) {
     channel: channelId,
     thread_ts: threadId,
     text: `<${message.permalink}|Original message>`,
+  });
+}
+
+export async function markThreadSuperseded(channelId, oldThreadTs, newThreadTs) {
+  const permalink = await getPermalink(channelId, newThreadTs);
+  return slackClient().chat.postMessage({
+    channel: channelId,
+    thread_ts: oldThreadTs,
+    text: `A new digest has been posted. <${permalink}|View it here>.`
   });
 }

--- a/src/slack.mjs
+++ b/src/slack.mjs
@@ -59,17 +59,30 @@ export function addReaction(channelId, messageTs, reaction) {
 }
 
 /**
- * Fetch all reply messages in a thread.
+ * Fetch all reply messages in a thread, handling Slack pagination.
  * @param {string} channelId
  * @param {string} threadTs
  * @returns {Promise<SlackMessage[]>}
  */
 export async function getThreadReplies(channelId, threadTs) {
-  const response = await slackClient().conversations.replies({
-    channel: channelId,
-    ts: threadTs
-  });
-  return response.messages ?? [];
+  /** @type {SlackMessage[]} */
+  const messages = [];
+  let cursor = undefined;
+
+  while (true) {
+    const response = await slackClient().conversations.replies({
+      channel: channelId,
+      ts: threadTs,
+      cursor
+    });
+
+    messages.push(...(response.messages ?? []));
+
+    cursor = response.response_metadata?.next_cursor || undefined;
+    if (!cursor) break;
+  }
+
+  return messages;
 }
 
 export function getPermalink(channelId, messageTs) {

--- a/src/slack.test.mjs
+++ b/src/slack.test.mjs
@@ -1,0 +1,73 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const mockReplies = vi.hoisted(() => vi.fn());
+
+vi.mock('@slack/web-api', () => ({
+  WebClient: function() {
+    return { conversations: { replies: mockReplies } };
+  },
+}));
+vi.mock('@actions/core', () => ({ getInput: vi.fn(() => 'mock-token') }));
+
+import { getThreadReplies } from './slack.mjs';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('getThreadReplies', () => {
+  it('returns all messages from a single-page thread', async () => {
+    mockReplies.mockResolvedValueOnce({
+      messages: [{ ts: '1.0' }, { ts: '2.0' }],
+      response_metadata: { next_cursor: '' },
+    });
+
+    const result = await getThreadReplies('C123', '50.0');
+
+    expect(result).toEqual([{ ts: '1.0' }, { ts: '2.0' }]);
+  });
+
+  it('fetches all pages when the thread spans multiple pages', async () => {
+    mockReplies
+      .mockResolvedValueOnce({
+        messages: [{ ts: '1.0' }, { ts: '2.0' }],
+        response_metadata: { next_cursor: 'cursor1' },
+      })
+      .mockResolvedValueOnce({
+        messages: [{ ts: '3.0' }, { ts: '4.0' }],
+        response_metadata: { next_cursor: '' },
+      });
+
+    const result = await getThreadReplies('C123', '50.0');
+
+    expect(result).toEqual([{ ts: '1.0' }, { ts: '2.0' }, { ts: '3.0' }, { ts: '4.0' }]);
+    expect(mockReplies).toHaveBeenCalledTimes(2);
+  });
+
+  it('passes the cursor on subsequent page requests', async () => {
+    mockReplies
+      .mockResolvedValueOnce({
+        messages: [{ ts: '1.0' }],
+        response_metadata: { next_cursor: 'cursor1' },
+      })
+      .mockResolvedValueOnce({
+        messages: [{ ts: '2.0' }],
+        response_metadata: {},
+      });
+
+    await getThreadReplies('C123', '50.0');
+
+    expect(mockReplies).toHaveBeenNthCalledWith(2, expect.objectContaining({ cursor: 'cursor1' }));
+  });
+
+  it('returns an empty array when messages is undefined', async () => {
+    mockReplies.mockResolvedValueOnce({
+      messages: undefined,
+      response_metadata: {},
+    });
+
+    const result = await getThreadReplies('C123', '50.0');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/workflow.mjs
+++ b/src/workflow.mjs
@@ -1,7 +1,7 @@
 import { getInput } from '@actions/core';
 import fs from 'fs';
 import { getPullRequestStatus, getReviewReactions } from './github.mjs';
-import { getPermalink, getMessagePage, getMessageByTimestamp } from './slack.mjs';
+import { getPermalink, getMessagePage, getMessageByTimestamp, getThreadReplies } from './slack.mjs';
 import { distinct } from './utils.mjs';
 
 /** @typedef {import('./slack.mjs').SlackMessage} SlackMessage */
@@ -155,6 +155,47 @@ export async function collectMessages(channelId, channelState, limit, maxPages, 
 
   console.info(`Processing ${result.length} messages`);
   return result;
+}
+
+/**
+ * Convert a Slack permalink URL to a message timestamp.
+ * Permalink format: https://workspace.slack.com/archives/CHANNEL/pTIMESTAMP
+ * where TIMESTAMP is the ts with the decimal removed (10 sec digits + 6 microsecond digits).
+ * @param {string} url
+ * @returns {string|null}
+ */
+function parseTsFromPermalink(url) {
+  const match = url.match(/\/p(\d{16})/);
+  if (!match) return null;
+  const digits = match[1];
+  return `${digits.slice(0, 10)}.${digits.slice(10)}`;
+}
+
+/**
+ * Build a map from original message ts to digest thread reply ts by fetching
+ * the thread under lastDigestThreadTimestamp and parsing each bot reply's
+ * "Original message" link.
+ *
+ * @param {string} channelId
+ * @param {string|null} lastDigestThreadTimestamp
+ * @returns {Promise<Map<string, string>>} Map from originalTs to digestThreadReplyTs
+ */
+export async function buildDigestThreadMap(channelId, lastDigestThreadTimestamp) {
+  if (!lastDigestThreadTimestamp) return new Map();
+
+  const threadMessages = await getThreadReplies(channelId, lastDigestThreadTimestamp);
+  const map = new Map();
+
+  for (const msg of threadMessages) {
+    const match = msg.text?.match(/<([^|>]+)\|Original message>/);
+    if (!match) continue;
+    const originalTs = parseTsFromPermalink(match[1]);
+    if (originalTs) {
+      map.set(originalTs, msg.ts);
+    }
+  }
+
+  return map;
 }
 
 export async function getAggregateStatus(pullRequests) {

--- a/src/workflow.test.mjs
+++ b/src/workflow.test.mjs
@@ -4,6 +4,7 @@ vi.mock('./slack.mjs', () => ({
   getMessagePage: vi.fn(),
   getMessageByTimestamp: vi.fn(),
   getPermalink: vi.fn(),
+  getThreadReplies: vi.fn(),
 }));
 vi.mock('./github.mjs', () => ({
   getPullRequestStatus: vi.fn(),
@@ -12,8 +13,8 @@ vi.mock('./github.mjs', () => ({
 vi.mock('@actions/core', () => ({ getInput: vi.fn() }));
 vi.mock('fs', () => ({ default: { readFileSync: vi.fn(), existsSync: vi.fn() } }));
 
-import { collectMessages, shouldProcess, getAggregateStatus, buildPrMessage, getConfig } from './workflow.mjs';
-import { getMessagePage, getMessageByTimestamp, getPermalink } from './slack.mjs';
+import { collectMessages, shouldProcess, getAggregateStatus, buildPrMessage, getConfig, buildDigestThreadMap } from './workflow.mjs';
+import { getMessagePage, getMessageByTimestamp, getPermalink, getThreadReplies } from './slack.mjs';
 import { getPullRequestStatus, getReviewReactions } from './github.mjs';
 import { getInput } from '@actions/core';
 import fs from 'fs';
@@ -376,5 +377,56 @@ describe('buildPrMessage', () => {
     const message = { ts: '1.0' };
     const result = await buildPrMessage('C123', message, pr, reactionConfig, false);
     expect(result.reactions).toEqual([]);
+  });
+});
+
+describe('buildDigestThreadMap', () => {
+  const DIGEST_TS = '100.0';
+  // ts 1700000000.000001 → permalink segment p1700000000000001
+  const ORIGINAL_TS = '1700000000.000001';
+  const ORIGINAL_PERMALINK = 'https://slack.com/archives/C123/p1700000000000001';
+  const REPLY_TS = '200.0';
+
+  it('returns an empty map when lastDigestThreadTimestamp is null', async () => {
+    const result = await buildDigestThreadMap('C123', null);
+
+    expect(getThreadReplies).not.toHaveBeenCalled();
+    expect(result.size).toBe(0);
+  });
+
+  it('maps original message ts to digest thread reply ts', async () => {
+    getThreadReplies.mockResolvedValue([
+      { ts: REPLY_TS, text: `<${ORIGINAL_PERMALINK}|Original message>` },
+    ]);
+
+    const result = await buildDigestThreadMap('C123', DIGEST_TS);
+
+    expect(result.get(ORIGINAL_TS)).toBe(REPLY_TS);
+  });
+
+  it('skips messages that do not contain an Original message link', async () => {
+    getThreadReplies.mockResolvedValue([
+      { ts: REPLY_TS, text: 'The following PRs are still open :thread:' },
+    ]);
+
+    const result = await buildDigestThreadMap('C123', DIGEST_TS);
+
+    expect(result.size).toBe(0);
+  });
+
+  it('builds entries for all matching replies in the thread', async () => {
+    const ORIGINAL_TS_2 = '1700000001.000002';
+    const PERMALINK_2 = 'https://slack.com/archives/C123/p1700000001000002';
+    const REPLY_TS_2 = '201.0';
+
+    getThreadReplies.mockResolvedValue([
+      { ts: REPLY_TS, text: `<${ORIGINAL_PERMALINK}|Original message>` },
+      { ts: REPLY_TS_2, text: `<${PERMALINK_2}|Original message>` },
+    ]);
+
+    const result = await buildDigestThreadMap('C123', DIGEST_TS);
+
+    expect(result.get(ORIGINAL_TS)).toBe(REPLY_TS);
+    expect(result.get(ORIGINAL_TS_2)).toBe(REPLY_TS_2);
   });
 });


### PR DESCRIPTION
## Summary
- When a PR is resolved (closed/merged), the same reaction is now mirrored to the corresponding entry in the most recent digest thread
- When a new digest thread is posted, a reply is added to the previous digest thread linking to the new one

## Test Plan
- [ ] React to a PR message with a closed/merged reaction — verify the same reaction appears on the PR's entry in the latest digest thread
- [ ] Post a new digest — verify the previous digest thread gets a reply with a link to the new digest

🤖 Generated with [Claude Code](https://claude.ai/claude-code)