### PR TITLE
ci: run tests and publish test report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
       
+      - name: Run tests
+        run: npm test
+
       - name: Run build
         run: npm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
   ci:
     name: CI
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -20,9 +23,17 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Run tests
-        run: npm test
+        run: npm test -- --reporter=verbose --reporter=junit --outputFile=test-results.xml
+
+      - name: Publish test report
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: Test Results
+          path: test-results.xml
+          reporter: java-junit
 
       - name: Run build
         run: npm run build


### PR DESCRIPTION
## Summary

- Adds a `Run tests` step (`npm test`) to the CI pipeline
- Outputs a JUnit XML report from Vitest
- Publishes the report as a GitHub Check via `dorny/test-reporter`, running even when tests fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)