### PR TITLE
refactor: move git commit/push out of action into workflow steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Get up and running in about 5 minutes.
 
   > [!NOTE]
   > This action uses two separate tokens for different purposes:
-  > - The workflow's **default `GITHUB_TOKEN`** (granted via the `contents: write` job permission) commits the state file back to the workflow repo.
+  > - The workflow's **default `GITHUB_TOKEN`** (granted via the `contents: write` job permission) is used to commit the state file back to the workflow repo.
   > - The **`github-token` input** reads PR statuses from the repos being monitored — these are typically different repos, so the default `GITHUB_TOKEN` won't work here.
 
-- A repository where the GitHub Actions actor has push access (required for [Persistent PR Tracking](#persistent-pr-tracking-trackunresolved) — see that section to opt out).
+- If using [Persistent PR Tracking](#persistent-pr-tracking-trackunresolved): a repository where the GitHub Actions actor has push access. See that section for the full workflow setup, or opt out by setting `trackUnresolved: false`.
 
 ### 1. Create a config file
 
@@ -96,6 +96,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4  # Required to read the config file and write the state file
 
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: PR Channel Slackbot
         uses: TheSench/pr-channel-slackbot@v2
         with:
@@ -103,6 +108,11 @@ jobs:
           github-token: ${{ secrets.PR_BOT_GITHUB_TOKEN }}
           config-file: '.github/pr_channel_slackbot_config.json'
           state-file: '.github/pr-channel-state.json'
+
+      - name: Commit state file
+        run: |
+          git add .github/pr-channel-state.json
+          git diff --cached --quiet || git commit -m "chore: update PR channel state [skip ci]" && git push
 ```
 
 ### 3. Store your secrets
@@ -271,6 +281,8 @@ The state file is automatically committed and pushed back to the repository afte
 
 - Set `contents: write` on the job permissions
 - Include `actions/checkout@v4` before the bot step
+- Configure git user identity before the bot step
+- Commit and push the state file after the bot step
 - Provide the `state-file` input (defaults to `./pr-channel-state.json`)
 
 ```yaml
@@ -324,6 +336,11 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Configure git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
       - name: PR Channel Slackbot
         uses: TheSench/pr-channel-slackbot@v2
         with:
@@ -332,6 +349,11 @@ jobs:
           config-file: '.github/pr_channel_slackbot_config.json'
           state-file: '.github/pr-channel-state.json'
           skip-digest: ${{ github.event_name == 'schedule' && github.event.schedule == '0 9-17 * * 1-5' || inputs.skip-digest }}
+
+      - name: Commit state file
+        run: |
+          git add .github/pr-channel-state.json
+          git diff --cached --quiet || git commit -m "chore: update PR channel state [skip ci]" && git push
 ```
 
 ## Migrating from v1
@@ -347,7 +369,7 @@ The `disableReactionCopying` field has been replaced by `enableReactionCopying` 
 
 Previously this field didn't exist and unresolved tracking was always off. In v2 it is on by default.
 
-- Requires adding `contents: write` permission to your workflow job AND the workflow actor must be allowed to commit directly to the branch.
+- Requires adding `contents: write` permission to your workflow job, a `git config` step to set user identity, a commit-and-push step after the bot runs, AND the workflow actor must be allowed to commit directly to the branch.
 - To restore the old behavior, explicitly set `"trackUnresolved": false` on each channel.
 
 ### `allowBotMessages` now defaults to `true`

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -50301,6 +50301,7 @@ function getChannelState(state, channelId) {
  * @param {Object.<string, ChannelState>} state
  */
 function saveState(stateFile, state) {
+  console.log(`Writing state changes to ${stateFile}`);
   fs__WEBPACK_IMPORTED_MODULE_0__.writeFileSync(stateFile, JSON.stringify(state, null, 2));
 }
 

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -37329,13 +37329,6 @@ module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("assert");
 
 /***/ }),
 
-/***/ 5317:
-/***/ ((module) => {
-
-module.exports = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("child_process");
-
-/***/ }),
-
 /***/ 6982:
 /***/ ((module) => {
 
@@ -42597,7 +42590,7 @@ module.exports = axios;
 
 /***/ }),
 
-/***/ 4116:
+/***/ 8179:
 /***/ ((__unused_webpack___webpack_module__, __webpack_exports__, __nccwpck_require__) => {
 
 
@@ -44046,8 +44039,8 @@ function toPlatformPath(pth) {
 var external_string_decoder_ = __nccwpck_require__(3193);
 // EXTERNAL MODULE: external "events"
 var external_events_ = __nccwpck_require__(4434);
-// EXTERNAL MODULE: external "child_process"
-var external_child_process_ = __nccwpck_require__(5317);
+;// CONCATENATED MODULE: external "child_process"
+const external_child_process_namespaceObject = __WEBPACK_EXTERNAL_createRequire(import.meta.url)("child_process");
 // EXTERNAL MODULE: external "assert"
 var external_assert_ = __nccwpck_require__(2613);
 ;// CONCATENATED MODULE: ./node_modules/@actions/io/lib/io-util.js
@@ -44889,7 +44882,7 @@ class ToolRunner extends external_events_.EventEmitter {
                     return reject(new Error(`The cwd: ${this.options.cwd} does not exist!`));
                 }
                 const fileName = this._getSpawnFileName();
-                const cp = external_child_process_.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
+                const cp = external_child_process_namespaceObject.spawn(fileName, this._getSpawnArgs(optionsNonNull), this._getSpawnOptions(this.options, fileName));
                 let stdbuffer = '';
                 if (cp.stdout) {
                     cp.stdout.on('data', (data) => {
@@ -45569,8 +45562,8 @@ __nccwpck_require__.d(__webpack_exports__, {
   BY: () => (/* binding */ getReviewReactions)
 });
 
-// EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js + 15 modules
-var core = __nccwpck_require__(4116);
+// EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js + 16 modules
+var core = __nccwpck_require__(8179);
 // EXTERNAL MODULE: external "fs"
 var external_fs_ = __nccwpck_require__(9896);
 // EXTERNAL MODULE: external "os"
@@ -50008,7 +50001,7 @@ __nccwpck_require__.a(__webpack_module__, async (__webpack_handle_async_dependen
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   e: () => (/* binding */ run)
 /* harmony export */ });
-/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(4116);
+/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(8179);
 /* harmony import */ var _workflow_mjs__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(9849);
 /* harmony import */ var _slack_mjs__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(165);
 /* harmony import */ var _github_mjs__WEBPACK_IMPORTED_MODULE_3__ = __nccwpck_require__(2474);
@@ -50109,7 +50102,7 @@ __webpack_async_result__();
 /* harmony export */   Zg: () => (/* binding */ getThreadReplies),
 /* harmony export */   iu: () => (/* binding */ getPermalink)
 /* harmony export */ });
-/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(4116);
+/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(8179);
 /* harmony import */ var _slack_web_api__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(5105);
 
 
@@ -50267,8 +50260,6 @@ async function markThreadSuperseded(channelId, oldThreadTs, newThreadTs) {
 /* harmony export */   LZ: () => (/* binding */ saveState)
 /* harmony export */ });
 /* harmony import */ var fs__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(9896);
-/* harmony import */ var child_process__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(5317);
-
 
 
 /**
@@ -50276,18 +50267,6 @@ async function markThreadSuperseded(channelId, oldThreadTs, newThreadTs) {
  * @property {Array<string>} unresolvedMessageTimestamps
  * @property {string|null} lastDigestThreadTimestamp
  */
-
-/**
- * Run a git command, throwing if it exits non-zero or fails to spawn.
- * @param {...string} args
- */
-function git(...args) {
-  const result = (0,child_process__WEBPACK_IMPORTED_MODULE_1__.spawnSync)('git', args, { stdio: 'inherit' });
-  if (result.error || result.status !== 0) {
-    const detail = result.error ? result.error.message : `exit status ${result.status}`;
-    throw new Error(`git ${args.join(' ')} failed: ${detail}`);
-  }
-}
 
 /**
  * Load state from the state file.
@@ -50317,27 +50296,12 @@ function getChannelState(state, channelId) {
 }
 
 /**
- * Write state to disk and commit it to the repo.
- * Skips the commit if the file has not changed.
- * Throws if git operations fail (caller should handle via setFailed).
+ * Write state to disk.
  * @param {string} stateFile
  * @param {Object.<string, ChannelState>} state
  */
 function saveState(stateFile, state) {
   fs__WEBPACK_IMPORTED_MODULE_0__.writeFileSync(stateFile, JSON.stringify(state, null, 2));
-  git('add', stateFile);
-  const diff = (0,child_process__WEBPACK_IMPORTED_MODULE_1__.spawnSync)('git', ['diff', '--cached', '--exit-code', '--', stateFile], { stdio: 'ignore' });
-  if (diff.error) throw new Error(`git diff failed: ${diff.error.message}`);
-  if (diff.status === 0) {
-    console.info('No changes to state file, skipping commit.');
-    return;
-  }
-  git('commit', '-m', 'chore: update PR channel state [skip ci]');
-  const refName = process.env.GITHUB_REF_NAME;
-  if (!refName) {
-    throw new Error('GITHUB_REF_NAME is not set; cannot push state file');
-  }
-  git('push', 'origin', `HEAD:refs/heads/${refName}`);
 }
 
 
@@ -50357,8 +50321,8 @@ __nccwpck_require__.d(__webpack_exports__, {
   Vb: () => (/* binding */ shouldProcess)
 });
 
-// EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js + 15 modules
-var core = __nccwpck_require__(4116);
+// EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js + 16 modules
+var core = __nccwpck_require__(8179);
 // EXTERNAL MODULE: external "fs"
 var external_fs_ = __nccwpck_require__(9896);
 // EXTERNAL MODULE: ./src/github.mjs + 22 modules

--- a/src/state.mjs
+++ b/src/state.mjs
@@ -39,5 +39,6 @@ export function getChannelState(state, channelId) {
  * @param {Object.<string, ChannelState>} state
  */
 export function saveState(stateFile, state) {
+  console.log(`Writing state changes to ${stateFile}`);
   fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
 }

--- a/src/state.mjs
+++ b/src/state.mjs
@@ -1,23 +1,10 @@
 import fs from 'fs';
-import { spawnSync } from 'child_process';
 
 /**
  * @typedef {Object} ChannelState
  * @property {Array<string>} unresolvedMessageTimestamps
  * @property {string|null} lastDigestThreadTimestamp
  */
-
-/**
- * Run a git command, throwing if it exits non-zero or fails to spawn.
- * @param {...string} args
- */
-function git(...args) {
-  const result = spawnSync('git', args, { stdio: 'inherit' });
-  if (result.error || result.status !== 0) {
-    const detail = result.error ? result.error.message : `exit status ${result.status}`;
-    throw new Error(`git ${args.join(' ')} failed: ${detail}`);
-  }
-}
 
 /**
  * Load state from the state file.
@@ -47,25 +34,10 @@ export function getChannelState(state, channelId) {
 }
 
 /**
- * Write state to disk and commit it to the repo.
- * Skips the commit if the file has not changed.
- * Throws if git operations fail (caller should handle via setFailed).
+ * Write state to disk.
  * @param {string} stateFile
  * @param {Object.<string, ChannelState>} state
  */
 export function saveState(stateFile, state) {
   fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
-  git('add', stateFile);
-  const diff = spawnSync('git', ['diff', '--cached', '--exit-code', '--', stateFile], { stdio: 'ignore' });
-  if (diff.error) throw new Error(`git diff failed: ${diff.error.message}`);
-  if (diff.status === 0) {
-    console.info('No changes to state file, skipping commit.');
-    return;
-  }
-  git('commit', '-m', 'chore: update PR channel state [skip ci]');
-  const refName = process.env.GITHUB_REF_NAME;
-  if (!refName) {
-    throw new Error('GITHUB_REF_NAME is not set; cannot push state file');
-  }
-  git('push', 'origin', `HEAD:refs/heads/${refName}`);
 }


### PR DESCRIPTION
## Summary

- Removes all `git add`/`git commit`/`git push` logic from `src/state.mjs` — `saveState` now just writes the JSON file
- Updates README workflow examples to include explicit `Configure git user` and `Commit state file` steps
- Updates prerequisites and `trackUnresolved` docs to reflect the new workflow requirements

## Why

The action was silently running git operations inside Node.js code, which made failures hard to debug and required users to trust the action's internal behavior. Moving commit/push to explicit workflow steps makes the workflow more transparent, composable (users can swap in their own commit action), and easier to troubleshoot when push permissions fail.

## Test Plan

- [ ] Verify tests pass (`npm test`)
- [ ] Verify build is clean (`npm run build && git diff --exit-code`)
- [ ] Test a workflow run with the new explicit commit steps