### PR TITLE
feat: find latest digest

### DIFF
--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -49999,7 +49999,9 @@ async function getReviewReactions(pullRequest, reactionConfig) {
 
 __nccwpck_require__.a(__webpack_module__, async (__webpack_handle_async_dependencies__, __webpack_async_result__) => { try {
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
-/* harmony export */   e: () => (/* binding */ run)
+/* harmony export */   U4: () => (/* binding */ isNewer),
+/* harmony export */   eF: () => (/* binding */ run),
+/* harmony export */   y2: () => (/* binding */ getLatestDigestThreadTimestamp)
 /* harmony export */ });
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(8179);
 /* harmony import */ var _workflow_mjs__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(9849);
@@ -50012,6 +50014,27 @@ __nccwpck_require__.a(__webpack_module__, async (__webpack_handle_async_dependen
 
 
 
+function isNewer(messageTs, digestThreadTimestamp) {
+  if (!digestThreadTimestamp) {
+    return true;
+  }
+
+  const currentTs = Number(messageTs);
+  const previousTs = Number(digestThreadTimestamp);
+
+  return Number.isFinite(currentTs) && Number.isFinite(previousTs) && currentTs > previousTs;
+}
+
+function getLatestDigestThreadTimestamp(channelState, botIdentity, messages) {
+  let digestThreadTimestamp = channelState.lastDigestThreadTimestamp;
+  for (let message of messages) {
+    if ((0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .isDigest */ .Bc)(message, botIdentity) && isNewer(message.ts, digestThreadTimestamp)) {
+      digestThreadTimestamp = message.ts;
+    }
+  }
+  return digestThreadTimestamp;
+}
+
 async function run() {
   try {
     const { reactionConfig, channelConfig } = (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .getConfig */ .zj)();
@@ -50019,11 +50042,13 @@ async function run() {
     const stateFile = (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__/* .getInput */ .V4)('state-file');
 
     const state = (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .loadState */ .C7)(stateFile);
+    const botIdentity = await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .getBotIdentity */ .E_)();
 
     for (let { channelId, limit, maxPages, trackUnresolved, enableReactionCopying, allowBotMessages } of channelConfig) {
       const channelState = (0,_state_mjs__WEBPACK_IMPORTED_MODULE_4__/* .getChannelState */ .F7)(state, channelId);
       const messages = await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .collectMessages */ .ZO)(channelId, channelState, limit, maxPages, trackUnresolved);
-      const digestThreadMap = await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .buildDigestThreadMap */ .tT)(channelId, channelState.lastDigestThreadTimestamp);
+      let lastDigestThreadTimestamp = getLatestDigestThreadTimestamp(channelState, botIdentity, messages);
+      const digestThreadMap = await (0,_workflow_mjs__WEBPACK_IMPORTED_MODULE_1__/* .buildDigestThreadMap */ .tT)(channelId, lastDigestThreadTimestamp);
 
       const messagesForDigest = [];
       const unresolvedTimestamps = [];
@@ -50056,20 +50081,17 @@ async function run() {
         }
       }
 
-      let digestThreadTimestamp;
-      if (skipDigest) {
-        digestThreadTimestamp = channelState.lastDigestThreadTimestamp;
-      } else {
-        digestThreadTimestamp = await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .postOpenPrs */ .Ek)(channelId, messagesForDigest);
+      if (!skipDigest) {
+        lastDigestThreadTimestamp = await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .postOpenPrs */ .Ek)(channelId, messagesForDigest);
         if (channelState.lastDigestThreadTimestamp) {
-          await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .markThreadSuperseded */ .Sg)(channelId, channelState.lastDigestThreadTimestamp, digestThreadTimestamp);
+          await (0,_slack_mjs__WEBPACK_IMPORTED_MODULE_2__/* .markThreadSuperseded */ .Sg)(channelId, channelState.lastDigestThreadTimestamp, lastDigestThreadTimestamp);
         }
       }
 
       if (trackUnresolved) {
         state[channelId] = {
           unresolvedMessageTimestamps: unresolvedTimestamps,
-          lastDigestThreadTimestamp: digestThreadTimestamp
+          lastDigestThreadTimestamp
         };
       }
     }
@@ -50095,13 +50117,16 @@ __webpack_async_result__();
 
 /* harmony export */ __nccwpck_require__.d(__webpack_exports__, {
 /* harmony export */   BB: () => (/* binding */ addReaction),
+/* harmony export */   Bc: () => (/* binding */ isDigest),
 /* harmony export */   Dh: () => (/* binding */ getMessagePage),
+/* harmony export */   E_: () => (/* binding */ getBotIdentity),
 /* harmony export */   Ek: () => (/* binding */ postOpenPrs),
 /* harmony export */   Ld: () => (/* binding */ getMessageByTimestamp),
 /* harmony export */   Sg: () => (/* binding */ markThreadSuperseded),
 /* harmony export */   Zg: () => (/* binding */ getThreadReplies),
 /* harmony export */   iu: () => (/* binding */ getPermalink)
 /* harmony export */ });
+/* unused harmony export isOwnMessage */
 /* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(8179);
 /* harmony import */ var _slack_web_api__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(5105);
 
@@ -50191,11 +50216,40 @@ async function getThreadReplies(channelId, threadTs) {
   return messages;
 }
 
+const DIGEST_HEADER_RESOLVED = 'All PRs are resolved! :tada:';
+const DIGEST_HEADER_OPEN = 'The following PRs are still open :thread:';
+
+const DIGEST_HEADER_TEXTS = [
+  DIGEST_HEADER_RESOLVED,
+  DIGEST_HEADER_OPEN
+];
+
 function getPermalink(channelId, messageTs) {
   return slackClient().chat.getPermalink({
     channel: channelId,
     message_ts: messageTs
   }).then(response => response.permalink);
+}
+
+function isDigest(message, identity) {
+  const text = message.text;
+  const headerBlockText = message.blocks?.find(block => block.type === 'header')?.text?.text;
+
+  return isOwnMessage(message, identity) && (
+    DIGEST_HEADER_TEXTS.includes(text) || DIGEST_HEADER_TEXTS.includes(headerBlockText)
+  );
+}
+
+async function getBotIdentity() {
+  const response = await slackClient().auth.test();
+  return {
+    userId: response.user_id,
+    botId: response.bot_id
+  };
+}
+
+function isOwnMessage(message, identity) {
+  return (identity.botId && message.bot_id === identity.botId) || message.user === identity.userId;
 }
 
 async function postOpenPrs(channelId, messages) {
@@ -50213,8 +50267,8 @@ async function postOpenPrs(channelId, messages) {
 
 async function postThreadHeader(channelId, prCount) {
   const header = (prCount === 0
-    ? 'All PRs are resolved! :tada:'
-    : 'The following PRs are still open :thread:');
+    ? DIGEST_HEADER_RESOLVED
+    : DIGEST_HEADER_OPEN);
   return slackClient().chat.postMessage({
     channel: channelId,
     text: header,
@@ -50764,6 +50818,8 @@ module.exports = /*#__PURE__*/JSON.parse('{"application/1d-interleaved-parityfec
 /******/ // This entry module used 'module' so it can't be inlined
 /******/ var __webpack_exports__ = __nccwpck_require__(9465);
 /******/ __webpack_exports__ = await __webpack_exports__;
-/******/ var __webpack_exports__run = __webpack_exports__.e;
-/******/ export { __webpack_exports__run as run };
+/******/ var __webpack_exports__getLatestDigestThreadTimestamp = __webpack_exports__.y2;
+/******/ var __webpack_exports__isNewer = __webpack_exports__.U4;
+/******/ var __webpack_exports__run = __webpack_exports__.eF;
+/******/ export { __webpack_exports__getLatestDigestThreadTimestamp as getLatestDigestThreadTimestamp, __webpack_exports__isNewer as isNewer, __webpack_exports__run as run };
 /******/ 

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -15,6 +15,16 @@ export function isNewer(messageTs, digestThreadTimestamp) {
   return Number.isFinite(currentTs) && Number.isFinite(previousTs) && currentTs > previousTs;
 }
 
+export function getLatestDigestThreadTimestamp(channelState, botIdentity, messages) {
+  let digestThreadTimestamp = channelState.lastDigestThreadTimestamp;
+  for (let message of messages) {
+    if (isDigest(message, botIdentity) && isNewer(message.ts, digestThreadTimestamp)) {
+      digestThreadTimestamp = message.ts;
+    }
+  }
+  return digestThreadTimestamp;
+}
+
 export async function run() {
   try {
     const { reactionConfig, channelConfig } = getConfig();
@@ -22,23 +32,18 @@ export async function run() {
     const stateFile = getInput('state-file');
 
     const state = loadState(stateFile);
+    const botIdentity = await getBotIdentity();
 
     for (let { channelId, limit, maxPages, trackUnresolved, enableReactionCopying, allowBotMessages } of channelConfig) {
       const channelState = getChannelState(state, channelId);
       const messages = await collectMessages(channelId, channelState, limit, maxPages, trackUnresolved);
-      const digestThreadMap = await buildDigestThreadMap(channelId, channelState.lastDigestThreadTimestamp);
-      const botIdentity = await getBotIdentity();
+      let lastDigestThreadTimestamp = getLatestDigestThreadTimestamp(channelState, botIdentity, messages);
+      const digestThreadMap = await buildDigestThreadMap(channelId, lastDigestThreadTimestamp);
 
       const messagesForDigest = [];
       const unresolvedTimestamps = [];
 
-      let digestThreadTimestamp = channelState.lastDigestThreadTimestamp;
-
       for (let message of messages) {
-        if (isDigest(message, botIdentity) && isNewer(message.ts, digestThreadTimestamp)) {
-          digestThreadTimestamp = message.ts;
-        }
-
         const pullRequests = extractPullRequests(message.text);
 
         if (!shouldProcess(message, pullRequests, reactionConfig, allowBotMessages)) {
@@ -67,16 +72,16 @@ export async function run() {
       }
 
       if (!skipDigest) {
-        digestThreadTimestamp = await postOpenPrs(channelId, messagesForDigest);
+        lastDigestThreadTimestamp = await postOpenPrs(channelId, messagesForDigest);
         if (channelState.lastDigestThreadTimestamp) {
-          await markThreadSuperseded(channelId, channelState.lastDigestThreadTimestamp, digestThreadTimestamp);
+          await markThreadSuperseded(channelId, channelState.lastDigestThreadTimestamp, lastDigestThreadTimestamp);
         }
       }
 
       if (trackUnresolved) {
         state[channelId] = {
           unresolvedMessageTimestamps: unresolvedTimestamps,
-          lastDigestThreadTimestamp: digestThreadTimestamp
+          lastDigestThreadTimestamp
         };
       }
     }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,8 +1,19 @@
 import { getBooleanInput, getInput, setFailed } from "@actions/core";
 import { getConfig, shouldProcess, getAggregateStatus, buildPrMessage, collectMessages, buildDigestThreadMap } from "./workflow.mjs";
-import { addReaction, postOpenPrs, markThreadSuperseded } from "./slack.mjs";
+import { addReaction, postOpenPrs, markThreadSuperseded, isDigest, getBotIdentity } from "./slack.mjs";
 import { extractPullRequests } from "./github.mjs";
 import { loadState, saveState, getChannelState } from "./state.mjs";
+
+export function isNewer(messageTs, digestThreadTimestamp) {
+  if (!digestThreadTimestamp) {
+    return true;
+  }
+
+  const currentTs = Number(messageTs);
+  const previousTs = Number(digestThreadTimestamp);
+
+  return Number.isFinite(currentTs) && Number.isFinite(previousTs) && currentTs > previousTs;
+}
 
 export async function run() {
   try {
@@ -16,11 +27,18 @@ export async function run() {
       const channelState = getChannelState(state, channelId);
       const messages = await collectMessages(channelId, channelState, limit, maxPages, trackUnresolved);
       const digestThreadMap = await buildDigestThreadMap(channelId, channelState.lastDigestThreadTimestamp);
+      const botIdentity = await getBotIdentity();
 
       const messagesForDigest = [];
       const unresolvedTimestamps = [];
 
+      let digestThreadTimestamp = channelState.lastDigestThreadTimestamp;
+
       for (let message of messages) {
+        if (isDigest(message, botIdentity) && isNewer(message.ts, digestThreadTimestamp)) {
+          digestThreadTimestamp = message.ts;
+        }
+
         const pullRequests = extractPullRequests(message.text);
 
         if (!shouldProcess(message, pullRequests, reactionConfig, allowBotMessages)) {
@@ -48,10 +66,7 @@ export async function run() {
         }
       }
 
-      let digestThreadTimestamp;
-      if (skipDigest) {
-        digestThreadTimestamp = channelState.lastDigestThreadTimestamp;
-      } else {
+      if (!skipDigest) {
         digestThreadTimestamp = await postOpenPrs(channelId, messagesForDigest);
         if (channelState.lastDigestThreadTimestamp) {
           await markThreadSuperseded(channelId, channelState.lastDigestThreadTimestamp, digestThreadTimestamp);

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -37,7 +37,7 @@ vi.mock('./state.mjs', () => ({
 import { run, isNewer } from './index.mjs';
 import { getConfig, collectMessages, shouldProcess, getAggregateStatus, buildPrMessage, buildDigestThreadMap } from './workflow.mjs';
 import { loadState, saveState, getChannelState } from './state.mjs';
-import { postOpenPrs, addReaction, markThreadSuperseded } from './slack.mjs';
+import { postOpenPrs, addReaction, markThreadSuperseded, isDigest } from './slack.mjs';
 import { extractPullRequests } from './github.mjs';
 import { getBooleanInput, setFailed } from '@actions/core';
 
@@ -144,6 +144,27 @@ describe('run()', () => {
       await run();
 
       expect(addReaction).toHaveBeenCalledTimes(1);
+    });
+
+    it('builds the digest thread map using the newest digest thread timestamp from fetched messages', async () => {
+      getConfig.mockReturnValue({
+        reactionConfig: { merged: ['merged'], closed: ['closed'] },
+        channelConfig: [{ ...BASE_CHANNEL, trackUnresolved: false }],
+      });
+      getChannelState.mockReturnValue({
+        unresolvedMessageTimestamps: [],
+        lastDigestThreadTimestamp: '123.0',
+      });
+      collectMessages.mockResolvedValue([
+        { ts: '124.0', text: 'regular message' },
+        { ts: '125.0', text: 'digest thread message' }
+      ]);
+      isDigest.mockImplementation((message) => message.ts === '125.0');
+      shouldProcess.mockReturnValue(false);
+
+      await run();
+
+      expect(buildDigestThreadMap).toHaveBeenCalledWith('C123', '125.0');
     });
   });
 

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -19,6 +19,8 @@ vi.mock('./slack.mjs', () => ({
   addReaction: vi.fn(),
   postOpenPrs: vi.fn().mockResolvedValue('digest-ts'),
   markThreadSuperseded: vi.fn().mockResolvedValue(undefined),
+  isDigest: vi.fn(() => false),
+  getBotIdentity: vi.fn().mockResolvedValue({ userId: 'U123', botId: 'B123' }),
 }));
 vi.mock('./github.mjs', () => ({
   extractPullRequests: vi.fn(() => []),
@@ -32,7 +34,7 @@ vi.mock('./state.mjs', () => ({
   })),
 }));
 
-import { run } from './index.mjs';
+import { run, isNewer } from './index.mjs';
 import { getConfig, collectMessages, shouldProcess, getAggregateStatus, buildPrMessage, buildDigestThreadMap } from './workflow.mjs';
 import { loadState, saveState, getChannelState } from './state.mjs';
 import { postOpenPrs, addReaction, markThreadSuperseded } from './slack.mjs';
@@ -253,6 +255,25 @@ describe('run()', () => {
       await run();
 
       expect(setFailed).toHaveBeenCalledWith('Config not found');
+    });
+  });
+
+  describe('isNewer', () => {
+    it('returns true when there is no previous digest timestamp', () => {
+      expect(isNewer('123.0', null)).toBe(true);
+    });
+
+    it('returns true when the message timestamp is newer', () => {
+      expect(isNewer('124.0', '123.0')).toBe(true);
+    });
+
+    it('returns false when the message timestamp is older', () => {
+      expect(isNewer('122.0', '123.0')).toBe(false);
+    });
+
+    it('returns false when either timestamp is invalid', () => {
+      expect(isNewer('not-a-ts', '123.0')).toBe(false);
+      expect(isNewer('123.0', 'not-a-ts')).toBe(false);
     });
   });
 

--- a/src/slack.mjs
+++ b/src/slack.mjs
@@ -85,11 +85,26 @@ export async function getThreadReplies(channelId, threadTs) {
   return messages;
 }
 
+const DIGEST_HEADER_RESOLVED = 'All PRs are resolved! :tada:';
+const DIGEST_HEADER_OPEN = 'The following PRs are still open :thread:';
+
+const DIGEST_HEADER_TEXTS = [
+  DIGEST_HEADER_RESOLVED,
+  DIGEST_HEADER_OPEN
+];
+
 export function getPermalink(channelId, messageTs) {
   return slackClient().chat.getPermalink({
     channel: channelId,
     message_ts: messageTs
   }).then(response => response.permalink);
+}
+
+export function isDigest(message) {
+  const text = message.text;
+  const headerBlockText = message.blocks?.find(block => block.type === 'header')?.text?.text;
+
+  return DIGEST_HEADER_TEXTS.includes(text) || DIGEST_HEADER_TEXTS.includes(headerBlockText);
 }
 
 export async function postOpenPrs(channelId, messages) {
@@ -107,8 +122,8 @@ export async function postOpenPrs(channelId, messages) {
 
 async function postThreadHeader(channelId, prCount) {
   const header = (prCount === 0
-    ? 'All PRs are resolved! :tada:'
-    : 'The following PRs are still open :thread:');
+    ? DIGEST_HEADER_RESOLVED
+    : DIGEST_HEADER_OPEN);
   return slackClient().chat.postMessage({
     channel: channelId,
     text: header,

--- a/src/slack.mjs
+++ b/src/slack.mjs
@@ -100,11 +100,13 @@ export function getPermalink(channelId, messageTs) {
   }).then(response => response.permalink);
 }
 
-export function isDigest(message) {
+export function isDigest(message, identity) {
   const text = message.text;
   const headerBlockText = message.blocks?.find(block => block.type === 'header')?.text?.text;
 
-  return DIGEST_HEADER_TEXTS.includes(text) || DIGEST_HEADER_TEXTS.includes(headerBlockText);
+  return isOwnMessage(message, identity) && (
+    DIGEST_HEADER_TEXTS.includes(text) || DIGEST_HEADER_TEXTS.includes(headerBlockText)
+  );
 }
 
 export async function getBotIdentity() {

--- a/src/slack.mjs
+++ b/src/slack.mjs
@@ -107,6 +107,18 @@ export function isDigest(message) {
   return DIGEST_HEADER_TEXTS.includes(text) || DIGEST_HEADER_TEXTS.includes(headerBlockText);
 }
 
+export async function getBotIdentity() {
+  const response = await slackClient().auth.test();
+  return {
+    userId: response.user_id,
+    botId: response.bot_id
+  };
+}
+
+export function isOwnMessage(message, identity) {
+  return (identity.botId && message.bot_id === identity.botId) || message.user === identity.userId;
+}
+
 export async function postOpenPrs(channelId, messages) {
   const headerResponse = await postThreadHeader(channelId, messages.length);
   if (messages.length === 0) return headerResponse.ts;

--- a/src/slack.test.mjs
+++ b/src/slack.test.mjs
@@ -77,21 +77,24 @@ describe('getThreadReplies', () => {
 });
 
 describe('isDigest', () => {
-  it('returns true for the resolved digest header text', () => {
-    const message = { text: 'All PRs are resolved! :tada:' };
+  const identity = { userId: 'U123', botId: 'B123' };
 
-    expect(isDigest(message)).toBe(true);
+  it('returns true for the resolved digest header text from the bot', () => {
+    const message = { text: 'All PRs are resolved! :tada:', bot_id: 'B123' };
+
+    expect(isDigest(message, identity)).toBe(true);
   });
 
-  it('returns true for the open digest header text', () => {
-    const message = { text: 'The following PRs are still open :thread:' };
+  it('returns true for the open digest header text from the bot', () => {
+    const message = { text: 'The following PRs are still open :thread:', bot_id: 'B123' };
 
-    expect(isDigest(message)).toBe(true);
+    expect(isDigest(message, identity)).toBe(true);
   });
 
-  it('returns true for a digest header block', () => {
+  it('returns true for a digest header block from the bot', () => {
     const message = {
       text: 'fallback',
+      bot_id: 'B123',
       blocks: [
         {
           type: 'header',
@@ -100,13 +103,19 @@ describe('isDigest', () => {
       ]
     };
 
-    expect(isDigest(message)).toBe(true);
+    expect(isDigest(message, identity)).toBe(true);
   });
 
   it('returns false for non-digest messages', () => {
-    const message = { text: 'A regular message', blocks: [] };
+    const message = { text: 'A regular message', blocks: [], bot_id: 'B123' };
 
-    expect(isDigest(message)).toBe(false);
+    expect(isDigest(message, identity)).toBe(false);
+  });
+
+  it('returns false for digest text from another user', () => {
+    const message = { text: 'All PRs are resolved! :tada:', user: 'U999' };
+
+    expect(isDigest(message, identity)).toBe(false);
   });
 });
 

--- a/src/slack.test.mjs
+++ b/src/slack.test.mjs
@@ -1,15 +1,19 @@
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 
 const mockReplies = vi.hoisted(() => vi.fn());
+const mockAuthTest = vi.hoisted(() => vi.fn());
 
 vi.mock('@slack/web-api', () => ({
   WebClient: function() {
-    return { conversations: { replies: mockReplies } };
+    return {
+      auth: { test: mockAuthTest },
+      conversations: { replies: mockReplies }
+    };
   },
 }));
 vi.mock('@actions/core', () => ({ getInput: vi.fn(() => 'mock-token') }));
 
-import { getThreadReplies, isDigest } from './slack.mjs';
+import { getBotIdentity, getThreadReplies, isDigest, isOwnMessage } from './slack.mjs';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -103,5 +107,45 @@ describe('isDigest', () => {
     const message = { text: 'A regular message', blocks: [] };
 
     expect(isDigest(message)).toBe(false);
+  });
+});
+
+describe('getBotIdentity', () => {
+  it('returns the authenticated user and bot ids', async () => {
+    mockAuthTest.mockResolvedValueOnce({ user_id: 'U123', bot_id: 'B123' });
+
+    const identity = await getBotIdentity();
+
+    expect(identity).toEqual({ userId: 'U123', botId: 'B123' });
+    expect(mockAuthTest).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isOwnMessage', () => {
+  const identity = { userId: 'U123', botId: 'B123' };
+
+  it('returns true when the message bot_id matches the bot identity', () => {
+    const message = { bot_id: 'B123' };
+
+    expect(isOwnMessage(message, identity)).toBe(true);
+  });
+
+  it('returns true when the message user matches the user identity', () => {
+    const message = { user: 'U123' };
+
+    expect(isOwnMessage(message, identity)).toBe(true);
+  });
+
+  it('returns false for messages from other users', () => {
+    const message = { bot_id: 'B999', user: 'U999' };
+
+    expect(isOwnMessage(message, identity)).toBe(false);
+  });
+
+  it('works when the identity has no botId', () => {
+    const message = { bot_id: 'B123', user: 'U123' };
+    const identityWithoutBot = { userId: 'U123' };
+
+    expect(isOwnMessage(message, identityWithoutBot)).toBe(true);
   });
 });

--- a/src/slack.test.mjs
+++ b/src/slack.test.mjs
@@ -9,7 +9,7 @@ vi.mock('@slack/web-api', () => ({
 }));
 vi.mock('@actions/core', () => ({ getInput: vi.fn(() => 'mock-token') }));
 
-import { getThreadReplies } from './slack.mjs';
+import { getThreadReplies, isDigest } from './slack.mjs';
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -69,5 +69,39 @@ describe('getThreadReplies', () => {
     const result = await getThreadReplies('C123', '50.0');
 
     expect(result).toEqual([]);
+  });
+});
+
+describe('isDigest', () => {
+  it('returns true for the resolved digest header text', () => {
+    const message = { text: 'All PRs are resolved! :tada:' };
+
+    expect(isDigest(message)).toBe(true);
+  });
+
+  it('returns true for the open digest header text', () => {
+    const message = { text: 'The following PRs are still open :thread:' };
+
+    expect(isDigest(message)).toBe(true);
+  });
+
+  it('returns true for a digest header block', () => {
+    const message = {
+      text: 'fallback',
+      blocks: [
+        {
+          type: 'header',
+          text: { type: 'plain_text', text: 'The following PRs are still open :thread:' }
+        }
+      ]
+    };
+
+    expect(isDigest(message)).toBe(true);
+  });
+
+  it('returns false for non-digest messages', () => {
+    const message = { text: 'A regular message', blocks: [] };
+
+    expect(isDigest(message)).toBe(false);
   });
 });


### PR DESCRIPTION
This PR updates the bot to check for recently created digest messages in case there is one newer than what is stored in channel state (or if there is none stored yet).  This ensures that the logic of adding closed/merged reactions to the most recent digest and adding a pointer from that digest's thread to a newly created digest both always operate on the latest digest.

> [!NOTE]
> There is a small chance that the most recent digest is not found within the paged messages.  This is low-risk.  The main goal of this feature is to allow for auto-correction for either projects upgrading from v1 where we did not track recent digests or where a digest was created but an error occurred when saving state.